### PR TITLE
feat(infrastructure): add MSW v2 local mock system for development

### DIFF
--- a/.claude/CONSTITUTION.md
+++ b/.claude/CONSTITUTION.md
@@ -222,6 +222,10 @@ VITE_INSFORGE_ANON_KEY=
 VITE_APP_NAME="Gio Barber Shop"
 VITE_APP_ENV=development   # development | preview | production
 VITE_GOOGLE_CLIENT_ID=
+
+# Mocks locales — solo en .env.local (gitignoreado), nunca en otros envs
+VITE_USE_MOCKS=false          # activa MSW browser worker en dev
+VITE_MOCK_ROLE=client         # rol del usuario fake al hacer login: "client" | "admin"
 ```
 
 Nunca commitear `.env*` excepto `.env.example`.

--- a/.claude/KNOWLEDGE.md
+++ b/.claude/KNOWLEDGE.md
@@ -34,3 +34,12 @@ _(vacío)_
 ## Tips útiles
 
 _(vacío)_
+
+## Convenciones del proyecto
+
+### Los mocks deben mantenerse sincronizados con el API real
+
+**Contexto**: `src/mocks/` contiene handlers MSW que simulan el API de Supabase (InsForge).
+**Regla**: Cualquier cambio en la capa `infrastructure/` que afecte a endpoints, nombres de tabla, columnas o forma de la respuesta **debe reflejarse también en el handler y fixture correspondiente de `src/mocks/`**. Si no, los mocks dejan de representar el comportamiento real y se vuelven engañosos.
+**Cómo aplicarlo**: Al modificar un adaptador InsForge, buscar el handler MSW equivalente (`src/mocks/handlers/<dominio>.ts`) y actualizar la URL, estructura de respuesta y fixtures afectados en el mismo commit.
+**Fixtures como fuente de verdad compartida**: `src/mocks/data/*.ts` se commitean al repo. Son los datos de partida para todos los devs. Si durante pruebas locales añades datos valiosos, edita el fixture y haz commit para que el resto del equipo los tenga.

--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,9 @@ VITE_APP_ENV=development
 
 # Google OAuth (opcional en fase inicial)
 VITE_GOOGLE_CLIENT_ID=tu-google-client-id
+
+# Mocks locales (solo desarrollo — copiar a .env.local, nunca commitear)
+# Activa MSW para interceptar peticiones sin Supabase real
+VITE_USE_MOCKS=false
+# Rol del usuario fake al hacer login con el mock de auth: "client" | "admin"
+VITE_MOCK_ROLE=client

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "globals": "^17.5.0",
     "husky": "^9.1.7",
     "jsdom": "^29.0.2",
+    "msw": "^2.13.4",
     "prettier": "^3.8.3",
     "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^4.2.2",
@@ -66,5 +67,10 @@
     "typescript-eslint": "^8.58.2",
     "vite": "^6.2.0",
     "vitest": "^4.1.4"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
+      msw:
+        specifier: ^2.13.4
+        version: 2.13.4(@types/node@20.19.39)(typescript@5.7.3)
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -131,7 +134,7 @@ importers:
         version: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@20.19.39)(jsdom@29.0.2)(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.1.4(@types/node@20.19.39)(jsdom@29.0.2)(msw@2.13.4(@types/node@20.19.39)(typescript@5.7.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
 
@@ -586,6 +589,41 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/ansi@2.0.5':
+    resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/confirm@6.0.11':
+    resolution: {integrity: sha512-pTpHjg0iEIRMYV/7oCZUMf27/383E6Wyhfc/MY+AVQGEoUobffIYWOK9YLP2XFRGz/9i6WlTQh1CkFVIo2Y7XA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.8':
+    resolution: {integrity: sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.5':
+    resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/type@4.0.5':
+    resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -601,6 +639,22 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mswjs/interceptors@0.41.3':
+    resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
+    engines: {node: '>=18'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -956,6 +1010,12 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1141,6 +1201,10 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1382,8 +1446,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1445,6 +1518,13 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -1519,6 +1599,9 @@ packages:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-obj@2.0.0:
     resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
@@ -1733,6 +1816,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.13.4:
+    resolution: {integrity: sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1754,6 +1851,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -1781,6 +1881,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1884,6 +1987,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  rettime@0.11.7:
+    resolution: {integrity: sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==}
+
   rollup-plugin-visualizer@7.0.1:
     resolution: {integrity: sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==}
     engines: {node: '>=22'}
@@ -1925,6 +2031,9 @@ packages:
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
@@ -1939,6 +2048,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1950,8 +2063,15 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1975,6 +2095,10 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -2026,6 +2150,10 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
   typescript-eslint@8.58.2:
     resolution: {integrity: sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2044,6 +2172,9 @@ packages:
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2656,6 +2787,33 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@inquirer/ansi@2.0.5': {}
+
+  '@inquirer/confirm@6.0.11(@types/node@20.19.39)':
+    dependencies:
+      '@inquirer/core': 11.1.8(@types/node@20.19.39)
+      '@inquirer/type': 4.0.5(@types/node@20.19.39)
+    optionalDependencies:
+      '@types/node': 20.19.39
+
+  '@inquirer/core@11.1.8(@types/node@20.19.39)':
+    dependencies:
+      '@inquirer/ansi': 2.0.5
+      '@inquirer/figures': 2.0.5
+      '@inquirer/type': 4.0.5(@types/node@20.19.39)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 20.19.39
+
+  '@inquirer/figures@2.0.5': {}
+
+  '@inquirer/type@4.0.5(@types/node@20.19.39)':
+    optionalDependencies:
+      '@types/node': 20.19.39
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2674,6 +2832,26 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mswjs/interceptors@0.41.3':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
@@ -2940,6 +3118,12 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@types/statuses@2.0.6': {}
+
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.7.3))(eslint@10.2.0(jiti@2.6.1))(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3052,12 +3236,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.4(msw@2.13.4(@types/node@20.19.39)(typescript@5.7.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.13.4(@types/node@20.19.39)(typescript@5.7.3)
       vite: 6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.1.4':
@@ -3161,6 +3346,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cli-width@4.1.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -3424,7 +3611,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3474,6 +3671,13 @@ snapshots:
   globals@17.5.0: {}
 
   graceful-fs@4.2.11: {}
+
+  graphql@16.13.2: {}
+
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
 
   hermes-estree@0.25.1: {}
 
@@ -3527,6 +3731,8 @@ snapshots:
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
+
+  is-node-process@1.2.0: {}
 
   is-obj@2.0.0: {}
 
@@ -3698,6 +3904,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.13.4(@types/node@20.19.39)(typescript@5.7.3):
+    dependencies:
+      '@inquirer/confirm': 6.0.11(@types/node@20.19.39)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.13.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.7
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.6.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@3.0.0: {}
+
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
@@ -3723,6 +3956,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  outvariant@1.4.3: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -3750,6 +3985,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -3828,6 +4065,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  rettime@0.11.7: {}
+
   rollup-plugin-visualizer@7.0.1(rollup@4.60.1):
     dependencies:
       open: 11.0.0
@@ -3882,6 +4121,8 @@ snapshots:
 
   set-cookie-parser@2.7.2: {}
 
+  set-cookie-parser@3.1.0: {}
+
   shallowequal@1.1.0: {}
 
   shebang-command@2.0.0:
@@ -3892,13 +4133,19 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
 
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@4.1.0: {}
+
+  strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
     dependencies:
@@ -3925,6 +4172,8 @@ snapshots:
       min-indent: 1.0.1
 
   symbol-tree@3.2.4: {}
+
+  tagged-tag@1.0.0: {}
 
   tailwind-merge@3.5.0: {}
 
@@ -3965,6 +4214,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typescript-eslint@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.7.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@5.7.3))(eslint@10.2.0(jiti@2.6.1))(typescript@5.7.3)
@@ -3981,6 +4234,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici@7.25.0: {}
+
+  until-async@3.0.2: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
@@ -4006,10 +4261,10 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@4.1.4(@types/node@20.19.39)(jsdom@29.0.2)(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)):
+  vitest@4.1.4(@types/node@20.19.39)(jsdom@29.0.2)(msw@2.13.4(@types/node@20.19.39)(typescript@5.7.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.4(msw@2.13.4(@types/node@20.19.39)(typescript@5.7.3))(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.13.4'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,14 +15,23 @@ const queryClient = new QueryClient({
   },
 })
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <HelmetProvider>
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </QueryClientProvider>
-    </HelmetProvider>
-  </StrictMode>
-)
+async function bootstrap() {
+  if (import.meta.env.VITE_USE_MOCKS === 'true') {
+    const { worker } = await import('./mocks/browser')
+    await worker.start({ onUnhandledRequest: 'warn' })
+  }
+
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <HelmetProvider>
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </QueryClientProvider>
+      </HelmetProvider>
+    </StrictMode>,
+  )
+}
+
+bootstrap()

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser'
+import { handlers } from './handlers'
+
+export const worker = setupWorker(...handlers)

--- a/src/mocks/data/appointments.ts
+++ b/src/mocks/data/appointments.ts
@@ -1,0 +1,94 @@
+export type AppointmentStatus = 'pending' | 'confirmed' | 'completed' | 'cancelled'
+
+export interface MockAppointment {
+  id: string
+  client_id: string
+  barber_id: string
+  service_id: string
+  scheduled_at: string
+  duration_minutes: number
+  status: AppointmentStatus
+  notes: string | null
+  price: number
+  created_at: string
+}
+
+const CLIENT_ID = 'a1b2c3d4-0000-0000-0000-000000000001'
+
+export const mockAppointments: MockAppointment[] = [
+  // Pasadas — completadas
+  {
+    id: 'apt-0001',
+    client_id: CLIENT_ID,
+    barber_id: 'a1b2c3d4-0000-0000-0000-000000000002',
+    service_id: 'svc-0001',
+    scheduled_at: '2026-03-10T10:00:00.000Z',
+    duration_minutes: 20,
+    status: 'completed',
+    notes: null,
+    price: 15,
+    created_at: '2026-03-09T18:00:00.000Z',
+  },
+  {
+    id: 'apt-0002',
+    client_id: CLIENT_ID,
+    barber_id: 'b2c3d4e5-0000-0000-0000-000000000003',
+    service_id: 'svc-0003',
+    scheduled_at: '2026-04-01T11:30:00.000Z',
+    duration_minutes: 45,
+    status: 'completed',
+    notes: 'Dejar más largo en la parte superior.',
+    price: 25,
+    created_at: '2026-03-30T09:00:00.000Z',
+  },
+  // Futuras — confirmadas
+  {
+    id: 'apt-0003',
+    client_id: CLIENT_ID,
+    barber_id: 'a1b2c3d4-0000-0000-0000-000000000002',
+    service_id: 'svc-0002',
+    scheduled_at: '2026-04-25T10:00:00.000Z',
+    duration_minutes: 30,
+    status: 'confirmed',
+    notes: null,
+    price: 20,
+    created_at: '2026-04-17T14:00:00.000Z',
+  },
+  {
+    id: 'apt-0004',
+    client_id: CLIENT_ID,
+    barber_id: 'b2c3d4e5-0000-0000-0000-000000000003',
+    service_id: 'svc-0004',
+    scheduled_at: '2026-05-02T12:00:00.000Z',
+    duration_minutes: 20,
+    status: 'confirmed',
+    notes: null,
+    price: 12,
+    created_at: '2026-04-17T15:00:00.000Z',
+  },
+  // Pendientes de confirmación
+  {
+    id: 'apt-0005',
+    client_id: CLIENT_ID,
+    barber_id: 'a1b2c3d4-0000-0000-0000-000000000002',
+    service_id: 'svc-0003',
+    scheduled_at: '2026-05-10T09:30:00.000Z',
+    duration_minutes: 45,
+    status: 'pending',
+    notes: 'Primera visita.',
+    price: 25,
+    created_at: '2026-04-17T16:00:00.000Z',
+  },
+  {
+    id: 'apt-0006',
+    client_id: CLIENT_ID,
+    barber_id: 'b2c3d4e5-0000-0000-0000-000000000003',
+    service_id: 'svc-0001',
+    scheduled_at: '2026-05-15T17:00:00.000Z',
+    duration_minutes: 20,
+    status: 'pending',
+    notes: null,
+    price: 15,
+    created_at: '2026-04-17T17:00:00.000Z',
+  },
+]

--- a/src/mocks/data/barbers.ts
+++ b/src/mocks/data/barbers.ts
@@ -1,0 +1,30 @@
+export interface MockBarber {
+  id: string
+  full_name: string
+  bio: string | null
+  avatar_url: string | null
+  specialty_ids: string[]
+  is_active: boolean
+  created_at: string
+}
+
+export const mockBarbers: MockBarber[] = [
+  {
+    id: 'a1b2c3d4-0000-0000-0000-000000000002',
+    full_name: 'Giovanni Russo',
+    bio: 'Fundador de Gio Barber Shop. Más de 15 años de experiencia en cortes clásicos y modernos.',
+    avatar_url: null,
+    specialty_ids: ['svc-0001', 'svc-0002', 'svc-0003', 'svc-0004', 'svc-0005'],
+    is_active: true,
+    created_at: '2025-06-01T09:00:00.000Z',
+  },
+  {
+    id: 'b2c3d4e5-0000-0000-0000-000000000003',
+    full_name: 'Marco López',
+    bio: 'Especialista en degradados y diseños modernos. 8 años de experiencia.',
+    avatar_url: null,
+    specialty_ids: ['svc-0001', 'svc-0002', 'svc-0004'],
+    is_active: true,
+    created_at: '2025-09-15T09:00:00.000Z',
+  },
+]

--- a/src/mocks/data/services.ts
+++ b/src/mocks/data/services.ts
@@ -1,0 +1,57 @@
+export interface MockService {
+  id: string
+  name: string
+  description: string
+  duration_minutes: number
+  price: number
+  is_active: boolean
+  created_at: string
+}
+
+export const mockServices: MockService[] = [
+  {
+    id: 'svc-0001',
+    name: 'Corte clásico',
+    description: 'Corte de cabello tradicional con tijera y máquina, acabado con navaja.',
+    duration_minutes: 20,
+    price: 15,
+    is_active: true,
+    created_at: '2025-06-01T09:00:00.000Z',
+  },
+  {
+    id: 'svc-0002',
+    name: 'Degradado (Fade)',
+    description: 'Degradado suave o a piel, con volumen en la parte superior.',
+    duration_minutes: 30,
+    price: 20,
+    is_active: true,
+    created_at: '2025-06-01T09:00:00.000Z',
+  },
+  {
+    id: 'svc-0003',
+    name: 'Corte + Barba',
+    description: 'Corte completo más arreglo y definición de barba con navaja.',
+    duration_minutes: 45,
+    price: 25,
+    is_active: true,
+    created_at: '2025-06-01T09:00:00.000Z',
+  },
+  {
+    id: 'svc-0004',
+    name: 'Arreglo de barba',
+    description: 'Perfilado, afeitado y definición de barba con toalla caliente.',
+    duration_minutes: 20,
+    price: 12,
+    is_active: true,
+    created_at: '2025-06-01T09:00:00.000Z',
+  },
+  {
+    id: 'svc-0005',
+    name: 'Cejas',
+    description: 'Depilación y perfilado de cejas con hilo o cera.',
+    duration_minutes: 10,
+    price: 8,
+    is_active: true,
+    created_at: '2025-06-01T09:00:00.000Z',
+  },
+]

--- a/src/mocks/data/users.ts
+++ b/src/mocks/data/users.ts
@@ -1,0 +1,40 @@
+export type MockRole = 'client' | 'admin'
+
+export interface MockUser {
+  id: string
+  email: string
+  full_name: string
+  role: MockRole
+  phone: string | null
+  avatar_url: string | null
+  loyalty_points: number
+  created_at: string
+}
+
+export const mockUsers: Record<MockRole, MockUser> = {
+  client: {
+    id: 'a1b2c3d4-0000-0000-0000-000000000001',
+    email: 'carlos@example.com',
+    full_name: 'Carlos Romero',
+    role: 'client',
+    phone: '+34 612 345 678',
+    avatar_url: null,
+    loyalty_points: 150,
+    created_at: '2026-01-10T10:00:00.000Z',
+  },
+  admin: {
+    id: 'a1b2c3d4-0000-0000-0000-000000000002',
+    email: 'gio@giobarber.com',
+    full_name: 'Giovanni Russo',
+    role: 'admin',
+    phone: '+34 623 456 789',
+    avatar_url: null,
+    loyalty_points: 0,
+    created_at: '2025-06-01T09:00:00.000Z',
+  },
+}
+
+export function getMockUser(): MockUser {
+  const role = (import.meta.env.VITE_MOCK_ROLE as MockRole) ?? 'client'
+  return mockUsers[role] ?? mockUsers.client
+}

--- a/src/mocks/handlers/appointments.ts
+++ b/src/mocks/handlers/appointments.ts
@@ -1,0 +1,48 @@
+import { http, HttpResponse } from 'msw'
+import { mockAppointments, type MockAppointment } from '../data/appointments'
+
+// In-memory store inicializado con los fixtures — resetea al recargar la página
+const appointmentsStore: MockAppointment[] = [...mockAppointments]
+
+export const appointmentsHandlers = [
+  // GET /rest/v1/appointments — Supabase envía filtros como query params (ej: client_id=eq.xxx)
+  http.get('*/rest/v1/appointments', ({ request }) => {
+    const url = new URL(request.url)
+    const clientIdFilter = url.searchParams.get('client_id')
+
+    let result = appointmentsStore
+    if (clientIdFilter?.startsWith('eq.')) {
+      const clientId = clientIdFilter.replace('eq.', '')
+      result = appointmentsStore.filter((a) => a.client_id === clientId)
+    }
+
+    return HttpResponse.json(result)
+  }),
+
+  // POST /rest/v1/appointments — crea cita (en memoria, se pierde al recargar)
+  http.post('*/rest/v1/appointments', async ({ request }) => {
+    const body = (await request.json()) as Omit<MockAppointment, 'id' | 'created_at'>
+    const newAppointment: MockAppointment = {
+      ...body,
+      id: `apt-${Date.now()}`,
+      created_at: new Date().toISOString(),
+    }
+    appointmentsStore.push(newAppointment)
+    return HttpResponse.json(newAppointment, { status: 201 })
+  }),
+
+  // PATCH /rest/v1/appointments — actualiza estado (ej: cancelar cita)
+  http.patch('*/rest/v1/appointments', async ({ request }) => {
+    const url = new URL(request.url)
+    const idFilter = url.searchParams.get('id')?.replace('eq.', '')
+    const body = (await request.json()) as Partial<MockAppointment>
+
+    const index = appointmentsStore.findIndex((a) => a.id === idFilter)
+    if (index === -1) {
+      return HttpResponse.json({ message: 'Not found' }, { status: 404 })
+    }
+
+    appointmentsStore[index] = { ...appointmentsStore[index], ...body }
+    return HttpResponse.json(appointmentsStore[index])
+  }),
+]

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,0 +1,63 @@
+import { http, HttpResponse } from 'msw'
+import { getMockUser } from '../data/users'
+
+interface SupabaseSession {
+  access_token: string
+  refresh_token: string
+  token_type: string
+  expires_in: number
+  user: Record<string, unknown>
+}
+
+// In-memory auth state — resets on page reload (intentional: see KNOWLEDGE.md)
+let currentSession: SupabaseSession | null = null
+
+function buildSupabaseUser(user: ReturnType<typeof getMockUser>) {
+  return {
+    id: user.id,
+    email: user.email,
+    role: 'authenticated',
+    aud: 'authenticated',
+    created_at: user.created_at,
+    app_metadata: { provider: 'email', role: user.role },
+    user_metadata: {
+      full_name: user.full_name,
+      phone: user.phone,
+      loyalty_points: user.loyalty_points,
+    },
+  }
+}
+
+export const authHandlers = [
+  // GET /auth/v1/user — devuelve usuario si hay sesión activa, 401 si no
+  http.get('*/auth/v1/user', ({ request }) => {
+    const token = request.headers.get('Authorization')?.replace('Bearer ', '')
+    if (!token || !currentSession || token !== currentSession.access_token) {
+      return HttpResponse.json(
+        { message: 'invalid claim: missing sub claim' },
+        { status: 401 },
+      )
+    }
+    return HttpResponse.json(currentSession.user)
+  }),
+
+  // POST /auth/v1/token?grant_type=password — login fake con cualquier credencial
+  http.post('*/auth/v1/token', () => {
+    const user = getMockUser()
+    const accessToken = `mock-token-${user.role}-${Date.now()}`
+    currentSession = {
+      access_token: accessToken,
+      refresh_token: `mock-refresh-${Date.now()}`,
+      token_type: 'bearer',
+      expires_in: 3600,
+      user: buildSupabaseUser(user),
+    }
+    return HttpResponse.json(currentSession)
+  }),
+
+  // POST /auth/v1/logout
+  http.post('*/auth/v1/logout', () => {
+    currentSession = null
+    return new HttpResponse(null, { status: 204 })
+  }),
+]

--- a/src/mocks/handlers/barbers.ts
+++ b/src/mocks/handlers/barbers.ts
@@ -1,0 +1,10 @@
+import { http, HttpResponse } from 'msw'
+import { mockBarbers } from '../data/barbers'
+
+export const barbersHandlers = [
+  // Supabase filtra perfiles de barberos con ?role=eq.admin o vía join
+  // El handler devuelve todos los barberos activos sin filtrar (simplificado para mocks)
+  http.get('*/rest/v1/profiles', () => {
+    return HttpResponse.json(mockBarbers.filter((b) => b.is_active))
+  }),
+]

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,0 +1,11 @@
+import { authHandlers } from './auth'
+import { servicesHandlers } from './services'
+import { barbersHandlers } from './barbers'
+import { appointmentsHandlers } from './appointments'
+
+export const handlers = [
+  ...authHandlers,
+  ...servicesHandlers,
+  ...barbersHandlers,
+  ...appointmentsHandlers,
+]

--- a/src/mocks/handlers/services.ts
+++ b/src/mocks/handlers/services.ts
@@ -1,0 +1,8 @@
+import { http, HttpResponse } from 'msw'
+import { mockServices } from '../data/services'
+
+export const servicesHandlers = [
+  http.get('*/rest/v1/services', () => {
+    return HttpResponse.json(mockServices)
+  }),
+]

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+export const server = setupServer(...handlers)

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom'
+import { server } from '../mocks/server'
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,4 +23,8 @@ export default defineConfig({
     },
     assetsInlineLimit: 4096,
   },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['src/test/setup.ts'],
+  },
 })


### PR DESCRIPTION
## Summary
- Instala MSW v2 e intercepta las llamadas a Supabase en local sin tocar código de producción
- Login fake que acepta cualquier credencial; rol controlado por `VITE_MOCK_ROLE=client|admin`
- Fixtures realistas para servicios, barberos, citas y usuarios comprometidos en el repo
- Integración con Vitest (`msw/node`) para tests sin acceso a red

## Cómo probarlo

Crea `.env.local` con:
\`\`\`bash
VITE_USE_MOCKS=true
VITE_MOCK_ROLE=client   # o "admin"
\`\`\`

## Test plan
- [ ] `pnpm dev` → verificar `[MSW] Mocking enabled.` en consola del browser
- [ ] Hacer login con cualquier email/password → accede correctamente
- [ ] Cambiar `VITE_MOCK_ROLE=admin` y reiniciar → verifica cambio de rol
- [ ] `pnpm test:run` → exit 0
- [ ] `pnpm build` → sin errores, sin código de mocks en bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)