### PR TITLE
chore(ci): harden Claude workflow consistency

### DIFF
--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -7,9 +7,10 @@ Ejecuta todos los quality gates del proyecto y reporta el estado.
 Ejecuta estos comandos en secuencia y reporta el resultado de cada uno:
 
 ```bash
-npm run type-check
-npm run lint
-npm run test -- --run
+pnpm run type-check
+pnpm run lint
+pnpm run test:run
+bash .claude/scripts/validate-consistency.sh
 ```
 
 Formato del reporte:
@@ -18,6 +19,7 @@ Formato del reporte:
 ✅ TypeScript — sin errores
 ❌ ESLint — 3 errores en src/components/calendar/MonthCalendar.tsx
 ✅ Tests — 12 passed, 0 failed
+✅ Consistency — sin drift de quality gates ni reglas operativas
 ```
 
 Si hay errores, muéstralos completos y ofrécete a solucionarlos.

--- a/.claude/commands/done.md
+++ b/.claude/commands/done.md
@@ -17,9 +17,9 @@ Lanzar subagente de review siguiendo `.claude/workflows/review.md`.
 ### 3. Quality gates
 
 ```bash
-npm run type-check
-npm run lint
-npm run test -- --run
+pnpm run type-check
+pnpm run lint
+pnpm run test:run
 ```
 
 Si alguno falla → arreglar antes de continuar.

--- a/.claude/commands/learn.md
+++ b/.claude/commands/learn.md
@@ -16,7 +16,7 @@ Captura un aprendizaje reutilizable en `.claude/KNOWLEDGE.md`. Se usa cuando dur
 Ejemplos:
 
 - `/learn InsForge no soporta .rpc() con array args — hay que usar .sql() directo`
-- `/learn npm run dev a veces no hot-reloada si el workspace está en iCloud — reiniciar vite`
+- `/learn pnpm run dev a veces no hot-reloada si el workspace está en iCloud — reiniciar vite`
 
 ## Lo que debes hacer
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -48,9 +48,9 @@ Agent({
 ### 3. Ejecutar quality gates
 
 ```bash
-npm run type-check
-npm run lint
-npm run test -- --run
+pnpm run type-check
+pnpm run lint
+pnpm run test:run
 ```
 
 ### 4. Verificar criterios de aceptación

--- a/.claude/scripts/active-task.sh
+++ b/.claude/scripts/active-task.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Devuelve la ruta de la tarea activa asociada a la rama git actual, si existe.
-# Heurística: la tarea más reciente cuya rama coincida con el branch actual.
+# Estrategia:
+# 1) Match exacto por rama declarada en README.md de la tarea
+# 2) Fallback por slug (último segmento, segmento tras primer /, y rama con / -> -)
 # Salida: path de la carpeta o cadena vacía.
 set -euo pipefail
 
@@ -16,20 +18,51 @@ if [[ -z "$BRANCH" || "$BRANCH" == "HEAD" ]]; then
   exit 0
 fi
 
-# Slug deducido: todo lo que va detrás del "/" en la rama (feature/foo-bar → foo-bar)
-SLUG="${BRANCH#*/}"
+pick_latest() {
+  local current="${1:-}"
+  local candidate="${2:-}"
+  if [[ -z "$candidate" || ! -d "$candidate" ]]; then
+    echo "$current"
+    return
+  fi
+  if [[ -z "$current" || "$candidate" > "$current" ]]; then
+    echo "$candidate"
+    return
+  fi
+  echo "$current"
+}
 
-if [[ -z "$SLUG" || "$SLUG" == "$BRANCH" ]]; then
+LATEST=""
+
+# 1) Match exacto por rama en README
+for dir in "$TASKS_DIR"/TASK-*; do
+  [[ -d "$dir" ]] || continue
+  README="$dir/README.md"
+  [[ -f "$README" ]] || continue
+
+  TASK_BRANCH="$(grep -E '^- \*\*Rama\*\*:' "$README" 2>/dev/null | sed -nE 's/.*`([^`]+)`.*/\1/p' | head -1 || true)"
+  if [[ "$TASK_BRANCH" == "$BRANCH" ]]; then
+    LATEST="$(pick_latest "$LATEST" "$dir")"
+  fi
+done
+
+if [[ -n "$LATEST" ]]; then
+  echo "$LATEST"
   exit 0
 fi
 
-# Busca la carpeta más reciente que termine en "-$SLUG"
-LATEST=""
-for dir in "$TASKS_DIR"/TASK-*-"$SLUG"; do
-  [[ -d "$dir" ]] || continue
-  if [[ -z "$LATEST" || "$dir" > "$LATEST" ]]; then
-    LATEST="$dir"
-  fi
+# 2) Fallback por slugs candidatos
+declare -a CANDIDATES=()
+CANDIDATES+=("${BRANCH##*/}")
+CANDIDATES+=("${BRANCH#*/}")
+CANDIDATES+=("${BRANCH//\//-}")
+
+for slug in "${CANDIDATES[@]}"; do
+  [[ -n "$slug" ]] || continue
+  for dir in "$TASKS_DIR"/TASK-*-"$slug"; do
+    [[ -d "$dir" ]] || continue
+    LATEST="$(pick_latest "$LATEST" "$dir")"
+  done
 done
 
 echo "$LATEST"

--- a/.claude/scripts/context-watch.sh
+++ b/.claude/scripts/context-watch.sh
@@ -30,17 +30,21 @@ esac
 MSG=""
 
 case "$FILE_PATH" in
-  */domain/*/rules.ts)
+    */domain/*/rules.ts|*/domain/*/*.rules.ts|*/domain/*/rules.test.ts|*/domain/*/*.rules.test.ts)
     MSG="[context-watch] Editaste reglas de dominio → ¿cambió alguna regla de negocio? (Art. 4)" ;;
-  */domain/*/types.ts)
+    */domain/*/types.ts|*/domain/*/*.types.ts)
     MSG="[context-watch] Editaste tipos de dominio → ¿cambió el modelo de datos? (Art. 5)" ;;
-  */infrastructure/insforge/*.ts)
+    */infrastructure/insforge/*.ts|*/infrastructure/*insforge*/*.ts|*/mocks/handlers/*.ts|*/mocks/data/*.ts|*/supabase/migrations/*)
     MSG="[context-watch] Editaste infrastructure → ¿nuevo campo, tabla o mapper? (Art. 5)" ;;
-  */pages/*.tsx|*/router*|*/routes*|*App.tsx)
+    */pages/*.tsx|*/pages/*/*.tsx|*/pages/*/index.ts|*/pages/*/index.tsx|*/router*|*/routes*|*/components/auth/*|*/components/layout/*|*/App.tsx|*/main.tsx)
     MSG="[context-watch] Editaste rutas o páginas → ¿nueva ruta o cambio de AuthGuard? (Art. 6)" ;;
-  *.env*|*vite.config*)
+    */.claude/scripts/active-task.sh|*/.claude/scripts/diff-task.sh|*/.claude/commands/feature.md|*/.claude/commands/hotfix.md)
+      MSG="[context-watch] Editaste estrategia de rama/base → revisa Art. 9 para coherencia de flujo." ;;
+    */.claude/commands/check.md|*/.claude/commands/review.md|*/.claude/commands/done.md|*/.claude/workflows/review.md|*/.claude/workflows/refactor.md)
+      MSG="[context-watch] Editaste quality gates operativos → verifica Art. 14 (pnpm run type-check/lint/test:run)." ;;
+    *.env*|*vite.config*|*vercel.json|*/.github/workflows/*.yml|*/.github/workflows/*.yaml|*/src/config*|*/src/lib/env*)
     MSG="[context-watch] Editaste configuración → ¿nueva variable de entorno? (Art. 13)" ;;
-  */styles/*|*tailwind.config*)
+    */styles/*|*tailwind.config*|*components.json|*.css)
     MSG="[context-watch] Editaste estilos → ¿nuevo color o token no documentado? (Art. 10)" ;;
 esac
 

--- a/.claude/scripts/diff-task.sh
+++ b/.claude/scripts/diff-task.sh
@@ -9,15 +9,67 @@ ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 
 BRANCH="$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
 
-# Determina la base por convención de rama
-case "$BRANCH" in
-  hotfix/*) BASE="main" ;;
-  *)        BASE="develop" ;;
-esac
+trim() {
+  local s="$1"
+  s="${s#${s%%[![:space:]]*}}"
+  s="${s%${s##*[![:space:]]}}"
+  echo "$s"
+}
 
-# Verifica que la base existe
-if ! git -C "$ROOT_DIR" rev-parse --verify "$BASE" >/dev/null 2>&1; then
-  BASE="$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD~1 2>/dev/null || echo "HEAD~1")"
+resolve_existing_ref() {
+  local ref="$1"
+  ref="$(trim "$ref")"
+  if [[ -z "$ref" ]]; then
+    return
+  fi
+  if git -C "$ROOT_DIR" rev-parse --verify "$ref" >/dev/null 2>&1; then
+    echo "$ref"
+    return
+  fi
+  if git -C "$ROOT_DIR" rev-parse --verify "origin/$ref" >/dev/null 2>&1; then
+    echo "origin/$ref"
+    return
+  fi
+}
+
+BASE=""
+
+# 1) Intenta resolver base desde metadata de la tarea activa
+TASK_DIR="$(bash "$ROOT_DIR/.claude/scripts/active-task.sh" 2>/dev/null || echo "")"
+if [[ -n "$TASK_DIR" && -d "$TASK_DIR" && -f "$TASK_DIR/README.md" ]]; then
+  BASE_LINE="$(grep -E '^- \*\*Base\*\*:' "$TASK_DIR/README.md" 2>/dev/null | head -1 || true)"
+  if [[ -n "$BASE_LINE" ]]; then
+    BASE_CANDIDATE=""
+    BASE_CANDIDATE="$(echo "$BASE_LINE" | sed -nE 's/.*`([^`]+)`.*/\1/p' | head -1)"
+    if [[ -n "$BASE_CANDIDATE" ]]; then
+      BASE_CANDIDATE="$(trim "$BASE_CANDIDATE")"
+    fi
+    if [[ -z "$BASE_CANDIDATE" ]]; then
+      BASE_CANDIDATE="${BASE_LINE#*:}"
+      BASE_CANDIDATE="$(echo "$BASE_CANDIDATE" | awk -F' \| ' '{print $1}')"
+      BASE_CANDIDATE="$(trim "$BASE_CANDIDATE")"
+    fi
+    BASE="$(resolve_existing_ref "$BASE_CANDIDATE")"
+  fi
+fi
+
+# 2) Fallback por convención de rama
+if [[ -z "$BASE" ]]; then
+  case "$BRANCH" in
+    hotfix/*) BASE="$(resolve_existing_ref "main")" ;;
+    *)        BASE="$(resolve_existing_ref "develop")" ;;
+  esac
+fi
+
+# 3) Fallback por upstream de la rama actual
+if [[ -z "$BASE" ]]; then
+  UPSTREAM="$(git -C "$ROOT_DIR" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || echo "")"
+  BASE="$(resolve_existing_ref "$UPSTREAM")"
+fi
+
+# 4) Último recurso
+if [[ -z "$BASE" ]]; then
+  BASE="HEAD~1"
 fi
 
 if [[ "$MODE" == "--stat" ]]; then

--- a/.claude/scripts/sync-context.sh
+++ b/.claude/scripts/sync-context.sh
@@ -55,6 +55,12 @@ while IFS= read -r path; do
       check_path "$path" "3" "Arquitectura — cambio en capa controlada" ;;
   esac
 
+    # Art. 9 — Estrategia de ramas
+    case "$path" in
+      .claude/scripts/active-task.sh|.claude/scripts/diff-task.sh|.claude/commands/feature.md|.claude/commands/fix.md|.claude/commands/hotfix.md|.claude/commands/worktree.md)
+        check_path "$path" "9" "Estrategia de ramas/base — ¿sigue coherente con Art. 9?" ;;
+    esac
+
   # Art. 4 — Reglas de negocio
   case "$path" in
     src/domain/*/rules.ts|src/domain/*/rules.test.ts)
@@ -63,33 +69,39 @@ while IFS= read -r path; do
 
   # Art. 5 — Modelo de datos
   case "$path" in
-    src/domain/*/types.ts|src/infrastructure/insforge/*.ts|supabase/migrations/*)
+      src/domain/*/types.ts|src/domain/*/*.types.ts|src/infrastructure/insforge/*.ts|src/infrastructure/*/*.ts|src/mocks/handlers/*.ts|src/mocks/data/*.ts|supabase/migrations/*)
       check_path "$path" "5" "Modelo de datos — ¿nueva tabla, campo o relación?" ;;
   esac
 
   # Art. 6 — Rutas
   case "$path" in
-    src/pages/*|src/router*|src/routes*|src/App.tsx|src/main.tsx)
+      src/pages/*|src/pages/*/*|src/router*|src/routes*|src/App.tsx|src/main.tsx|src/components/auth/*|src/components/layout/*)
       check_path "$path" "6" "Rutas — ¿nueva ruta, AuthGuard nuevo o cambio de flujo de auth?" ;;
   esac
 
   # Art. 10 — Paleta de colores
   case "$path" in
-    src/*.css|tailwind.config*|*.css|src/styles/*)
+      src/*.css|src/*/*.css|src/*/*/*.css|tailwind.config*|components.json|*.css|src/styles/*)
       check_path "$path" "10" "Colores/estilos — ¿se usó un color o token nuevo?" ;;
   esac
 
   # Art. 11 — Rendimiento
   case "$path" in
-    src/pages/*.tsx|src/components/*.tsx)
+      src/pages/*.tsx|src/pages/*/*.tsx|src/components/*.tsx|src/components/*/*.tsx)
       check_path "$path" "11" "Rendimiento — ¿nuevo lazy(), memo o virtual?" ;;
   esac
 
   # Art. 13 — Variables de entorno
   case "$path" in
-    .env*|vite.config*|src/config*)
+      .env*|vite.config*|src/config*|src/lib/env*|.github/workflows/*.yml|.github/workflows/*.yaml|vercel.json)
       check_path "$path" "13" "Env vars — ¿nueva variable VITE_*?" ;;
   esac
+
+    # Art. 14 — Quality gates
+    case "$path" in
+      .claude/commands/check.md|.claude/commands/review.md|.claude/commands/done.md|.claude/workflows/review.md|.claude/workflows/refactor.md|package.json|.claude/settings.json)
+        check_path "$path" "14" "Quality gates — ¿se mantienen type-check/lint/test:run con pnpm?" ;;
+    esac
 
   # KNOWLEDGE.md
   case "$path" in

--- a/.claude/scripts/validate-consistency.sh
+++ b/.claude/scripts/validate-consistency.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Verifica consistencia del sistema agéntico:
+# - No usar npm run para quality gates operativos
+# - Presencia de comandos pnpm canónicos en archivos clave
+# - Scripts obligatorios en package.json
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+FAIL=0
+
+echo "[consistency] Running Claude system consistency checks..."
+
+DRIFT_OUTPUT="$({
+  grep -RInF "npm run type-check" "$ROOT_DIR/.claude/commands" "$ROOT_DIR/.claude/workflows" "$ROOT_DIR/docs" 2>/dev/null || true
+  grep -RInF "npm run lint" "$ROOT_DIR/.claude/commands" "$ROOT_DIR/.claude/workflows" "$ROOT_DIR/docs" 2>/dev/null || true
+  grep -RInF "npm run test -- --run" "$ROOT_DIR/.claude/commands" "$ROOT_DIR/.claude/workflows" "$ROOT_DIR/docs" 2>/dev/null || true
+  grep -InF "npm run type-check" "$ROOT_DIR/CLAUDE.md" "$ROOT_DIR/.github/copilot-instructions.md" 2>/dev/null || true
+  grep -InF "npm run lint" "$ROOT_DIR/CLAUDE.md" "$ROOT_DIR/.github/copilot-instructions.md" 2>/dev/null || true
+  grep -InF "npm run test -- --run" "$ROOT_DIR/CLAUDE.md" "$ROOT_DIR/.github/copilot-instructions.md" 2>/dev/null || true
+} | grep -v "pnpm run" | grep -vE '/\.claude/DECISIONS\.md:|/docs/07-consistency-checks\.md:' | sort -u || true)"
+
+if [[ -n "$DRIFT_OUTPUT" ]]; then
+  echo "[consistency] FAIL: Found legacy npm quality gate commands:" >&2
+  echo "$DRIFT_OUTPUT" >&2
+  FAIL=1
+else
+  echo "[consistency] OK: No legacy npm quality gate commands detected."
+fi
+
+declare -a REQUIRED_FILES=(
+  ".claude/commands/check.md"
+  ".claude/commands/review.md"
+  ".claude/commands/done.md"
+  ".claude/workflows/review.md"
+  ".claude/CONSTITUTION.md"
+)
+
+declare -a REQUIRED_CMDS=(
+  "pnpm run type-check"
+  "pnpm run lint"
+  "pnpm run test:run"
+)
+
+for rel in "${REQUIRED_FILES[@]}"; do
+  abs="$ROOT_DIR/$rel"
+  if [[ ! -f "$abs" ]]; then
+    echo "[consistency] FAIL: Missing required file $rel" >&2
+    FAIL=1
+    continue
+  fi
+
+  for cmd in "${REQUIRED_CMDS[@]}"; do
+    if ! grep -Fq "$cmd" "$abs"; then
+      echo "[consistency] FAIL: '$cmd' not found in $rel" >&2
+      FAIL=1
+    fi
+  done
+done
+
+if command -v jq >/dev/null 2>&1; then
+  if ! jq -e '.scripts["type-check"] and .scripts["lint"] and .scripts["test:run"]' "$ROOT_DIR/package.json" >/dev/null; then
+    echo "[consistency] FAIL: package.json is missing one of scripts: type-check, lint, test:run" >&2
+    FAIL=1
+  else
+    echo "[consistency] OK: package.json includes type-check, lint, and test:run scripts."
+  fi
+else
+  echo "[consistency] WARN: jq not available, package.json script validation skipped." >&2
+fi
+
+if [[ "$FAIL" -ne 0 ]]; then
+  echo "[consistency] Result: FAILED" >&2
+  exit 1
+fi
+
+echo "[consistency] Result: OK"

--- a/.claude/workflows/refactor.md
+++ b/.claude/workflows/refactor.md
@@ -43,7 +43,7 @@ bash .claude/scripts/art.sh 3   # arquitectura — siempre en refactors
 ## Fase IMPLEMENTACIÓN — invocada por `/implement`
 
 - Commits por cambio lógico small.
-- `npm run test -- --run` debe pasar tras cada commit.
+- `pnpm run test:run` debe pasar tras cada commit.
 - Si aparece un cambio de comportamiento → PARAR y avisar al usuario.
 
 ---

--- a/.claude/workflows/review.md
+++ b/.claude/workflows/review.md
@@ -52,9 +52,9 @@ Agent({
 ### 3. Quality gates
 
 ```bash
-npm run type-check
-npm run lint
-npm run test -- --run
+pnpm run type-check
+pnpm run lint
+pnpm run test:run
 ```
 
 ### 4. Verificar criterios de aceptación

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Copilot Project Instructions (Claude-style workflow)
+
+These instructions apply to all chat and code generation in this repository.
+
+## Source of truth
+
+- Read and follow `CLAUDE.md` first.
+- Treat `.claude/CONSTITUTION.md` (loaded through scripts) as normative.
+- Review `.claude/KNOWLEDGE.md` before proposing changes.
+
+## Startup checklist (minimal context)
+
+Run these commands before code changes:
+
+```bash
+bash .claude/scripts/constitution-index.sh
+bash .claude/scripts/art.sh 3
+bash .claude/scripts/art.sh 14
+bash .claude/scripts/active-task.sh
+bash .claude/scripts/fetch.sh STATE.md
+bash .claude/scripts/fetch.sh PLAN.md
+```
+
+Load only the specific extra articles or sections needed for the task.
+
+## Workflow contract
+
+- Do not modify `src/` unless the user explicitly requests implementation (equivalent to `/implement`).
+- During analysis or planning, write only under `.claude/tasks/<TASK-ID>/`.
+- Keep changes small and aligned to one plan step at a time.
+- Do not bypass quality gates.
+
+## Architecture and quality
+
+- Respect dependency flow:
+  - `pages -> components -> hooks -> infrastructure`
+  - `hooks` may import from `domain` and `infrastructure`
+  - `domain` stays pure (no framework or external service imports)
+- Before declaring a task done, run:
+  - `pnpm run type-check`
+  - `pnpm run lint`
+  - `pnpm run test:run`
+
+## Git hygiene
+
+- Follow commit format from Constitution Art. 8:
+  - `type(scope): imperative message in English`
+- Avoid destructive git commands unless explicitly requested by the user.
+
+## Priority when instructions conflict
+
+1. Direct user request
+2. `CLAUDE.md` and `.claude/CONSTITUTION.md`
+3. This file

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "github.copilot.chat.codeGeneration.useInstructionFiles": true,
+  "github.copilot.chat.codeGeneration.instructions": [
+    {
+      "file": ".github/copilot-instructions.md"
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
     ├── grep-task.sh       # grep en archivos de la tarea
     ├── diff-task.sh       # diff de la rama vs base
     ├── files-touched.sh   # archivos tocados (deduplicado)
+│       ├── validate-consistency.sh # chequeo anti-drift (quality gates + docs/comandos)
     ├── log-file-change.sh # hook PostToolUse
     ├── session-start.sh   # hook SessionStart
     └── pre-commit-check.sh # hook PreToolUse

--- a/docs/01-sistema-agentico.md
+++ b/docs/01-sistema-agentico.md
@@ -94,13 +94,13 @@ barber-dates-web/
     │       └── CHANGES/
     │           └── CHANGE-N.md  ← Una por cada /change ejecutado
     │
-    │  ─── Scripts (15 archivos) ─────────────────────────────────
+    │  ─── Scripts (16 archivos) ─────────────────────────────────
     └── scripts/
         ├── [tareas]     new-task.sh  active-task.sh
         ├── [fetch]      constitution-index.sh  art.sh  section.sh
         │                fetch.sh  plan-step.sh  grep-task.sh
         │                diff-task.sh  files-touched.sh
-        ├── [contexto]   sync-context.sh
+      ├── [contexto]   sync-context.sh  validate-consistency.sh
         └── [hooks]      log-file-change.sh  context-watch.sh
                          session-start.sh  pre-commit-check.sh
 ```
@@ -139,7 +139,7 @@ TÚ escribes: /feature appointment-system
 Hooks que actúan en paralelo:
   - Cada Edit/Write → log-file-change.sh  → actualiza files.md
   - Cada Edit/Write → context-watch.sh    → avisa si toca archivo sensible
-  - Cada Edit *.ts  → npm run type-check  → TypeScript en tiempo real
+  - Cada Edit *.ts  → pnpm run type-check  → TypeScript en tiempo real
   - git commit      → pre-commit-check.sh → sugiere TASK-id en el mensaje
   - Inicio sesión   → session-start.sh    → avisa si hay tarea activa
 ```

--- a/docs/02-archivos-de-contexto.md
+++ b/docs/02-archivos-de-contexto.md
@@ -102,7 +102,7 @@ La forma correcta es con el comando `/learn`:
 
 ```
 /learn InsForge no soporta .rpc() con array args — usar .sql() directo
-/learn npm run dev no hot-reloada en iCloud Drive — reiniciar Vite
+/learn pnpm run dev no hot-reloada en iCloud Drive — reiniciar Vite
 ```
 
 Claude añade la entrada con el formato correcto y la fecha.

--- a/docs/03-flujo-de-desarrollo.md
+++ b/docs/03-flujo-de-desarrollo.md
@@ -101,7 +101,7 @@ Todo desarrollo no trivial sigue este ciclo. Los comandos son los puntos de cont
 ║  Claude hace:                                                    ║
 ║    1. Lanza subagente independiente (no tiene el contexto tuyo)  ║
 ║       que audita el diff contra las reglas del Constitution      ║
-║    2. npm run type-check + lint + test                           ║
+║    2. pnpm run type-check + pnpm run lint + pnpm run test:run    ║
 ║    3. Verifica criterios de aceptación del README.md             ║
 ║    4. Escribe REVIEW.md con veredicto                            ║
 ║    5. Reporta: APROBADO o BLOQUEADO (con qué hay que arreglar)   ║

--- a/docs/05-sistema-de-tareas.md
+++ b/docs/05-sistema-de-tareas.md
@@ -160,6 +160,15 @@ bash .claude/scripts/sync-context.sh
 
 Cruza los archivos tocados contra un mapa de "qué archivos afectan a qué artículos". Devuelve una lista de artículos que podrían haber quedado desactualizados.
 
+#### `validate-consistency.sh`
+
+```bash
+bash .claude/scripts/validate-consistency.sh
+```
+
+Valida que no haya drift operativo entre comandos/workflows/docs y los quality gates canónicos del Constitution.
+Si detecta comandos legacy (`npm run ...`) o faltan comandos obligatorios en archivos clave, falla con exit code `1`.
+
 ---
 
 ## Hooks automáticos
@@ -223,7 +232,7 @@ Los hooks son scripts que se ejecutan automáticamente en respuesta a eventos de
 
 **Cuándo**: tras cada edición de un archivo TypeScript.
 
-**Qué hace**: ejecuta `npm run type-check` y muestra las últimas 20 líneas.
+**Qué hace**: ejecuta `pnpm run type-check` y muestra las últimas 20 líneas.
 
 **Por qué**: los errores de TypeScript se detectan inmediatamente, no al final de una sesión larga.
 

--- a/docs/07-consistency-checks.md
+++ b/docs/07-consistency-checks.md
@@ -1,0 +1,96 @@
+# 07 — Consistency Checks del Sistema Agéntico
+
+---
+
+## Objetivo
+
+Evitar drift entre lo que el sistema dice y lo que ejecuta realmente.
+
+En particular, este chequeo protege contra:
+
+- Reintroducir comandos legacy de quality gates con `npm run` en comandos/workflows/docs.
+- Olvidar los comandos canónicos de Art. 14 (`pnpm run type-check`, `pnpm run lint`, `pnpm run test:run`) en archivos operativos clave.
+- Perder scripts críticos en `package.json`.
+
+---
+
+## Script
+
+Ruta:
+
+```bash
+.claude/scripts/validate-consistency.sh
+```
+
+Ejecución directa:
+
+```bash
+bash .claude/scripts/validate-consistency.sh
+```
+
+Si todo está correcto, devuelve exit code `0` y muestra `Result: OK`.
+Si detecta drift, devuelve exit code `1` y lista los hallazgos.
+
+---
+
+## Qué valida
+
+### 1) Drift de comandos legacy
+
+Busca patrones `npm run type-check|lint|test -- --run` en:
+
+- `.claude/commands/`
+- `.claude/workflows/`
+- `docs/`
+- `CLAUDE.md`
+- `.github/copilot-instructions.md`
+
+### 2) Comandos canónicos obligatorios
+
+Valida que existan las 3 líneas canónicas en:
+
+- `.claude/commands/check.md`
+- `.claude/commands/review.md`
+- `.claude/commands/done.md`
+- `.claude/workflows/review.md`
+- `.claude/CONSTITUTION.md`
+
+### 3) Scripts en package.json
+
+Valida que `package.json` tenga:
+
+- `scripts.type-check`
+- `scripts.lint`
+- `scripts.test:run`
+
+---
+
+## Integración en el flujo
+
+El comando `/check` ya debe ejecutar:
+
+```bash
+pnpm run type-check
+pnpm run lint
+pnpm run test:run
+bash .claude/scripts/validate-consistency.sh
+```
+
+Recomendación operativa:
+
+- Ejecutarlo antes de `/review` si tocaste `.claude/`, `docs/` o `CLAUDE.md`.
+- Ejecutarlo siempre antes de `/done` en tareas de infraestructura del sistema agéntico.
+
+---
+
+## Qué hacer si falla
+
+1. Corrige primero los hallazgos de comandos legacy (`npm run ...`).
+2. Asegura presencia de las 3 líneas canónicas en archivos operativos.
+3. Si falta un script en `package.json`, restáuralo o ajusta la política de Art. 14 con aprobación explícita.
+
+---
+
+## Nota de diseño
+
+El chequeo está pensado para ser estricto en archivos operativos y flexible en registros históricos (por ejemplo ADRs que describen cambios pasados).

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 | [04-referencia-comandos.md](04-referencia-comandos.md)   | Los 31 comandos slash documentados en detalle                                                     |
 | [05-sistema-de-tareas.md](05-sistema-de-tareas.md)       | Carpetas TASK-, scripts de fetch parcial, hooks automáticos, continuidad entre sesiones           |
 | [06-buenas-practicas.md](06-buenas-practicas.md)         | Ahorro de tokens, correcciones con /change, estrategia git, errores comunes, ejemplos reales, FAQ |
+| [07-consistency-checks.md](07-consistency-checks.md)     | Validación automática de consistencia para evitar drift en quality gates y flujo agéntico         |
 
 ---
 


### PR DESCRIPTION
## Summary
- unify operational quality gates to `pnpm run type-check`, `pnpm run lint`, and `pnpm run test:run` across `.claude/commands`, `.claude/workflows`, and docs
- harden `.claude/scripts/active-task.sh` to resolve active task by exact branch match with robust slug fallbacks (including multi-level branch names)
- harden `.claude/scripts/diff-task.sh` to resolve base from task metadata first, then branch convention/upstream fallbacks
- expand `.claude/scripts/context-watch.sh` and `.claude/scripts/sync-context.sh` pattern coverage for Art. 9/13/14 and nested route/style/config changes
- add `.claude/scripts/validate-consistency.sh` and integrate it into `/check` to prevent command-drift regressions
- document consistency checks in `docs/07-consistency-checks.md` and update references in `docs/README.md` and `CLAUDE.md`

## Validation
- `pnpm run type-check` ✅
- `pnpm run lint` ✅
- `pnpm run test:run` ✅ (no test files, exit code 0)
- `bash .claude/scripts/validate-consistency.sh` ✅

## Notes
- project-level Copilot instruction wiring is included (`.github/copilot-instructions.md`, `.vscode/settings.json`) to keep this repository operating in Claude-like mode consistently.