### PR TITLE
ci(ci): deploy develop as production in PRE, add job summary URLs

### DIFF
--- a/.github/workflows/deploy-pre.yml
+++ b/.github/workflows/deploy-pre.yml
@@ -45,13 +45,13 @@ jobs:
       - run: npm install --global vercel@latest
 
       - name: Pull project settings
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ github.ref == 'refs/heads/develop' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PRE }}
 
       - name: Build
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ github.ref == 'refs/heads/develop' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PRE }}
@@ -60,7 +60,11 @@ jobs:
           VITE_APP_ENV: preview
 
       - name: Deploy
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          URL=$(vercel deploy --prebuilt ${{ github.ref == 'refs/heads/develop' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }})
+          echo "### PRE — ${{ github.ref == 'refs/heads/develop' && 'Production' || 'Preview' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**URL:** $URL" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PRE }}

--- a/.github/workflows/deploy-pre.yml
+++ b/.github/workflows/deploy-pre.yml
@@ -30,6 +30,8 @@ jobs:
     name: Deploy to Vercel PRE
     needs: quality
     runs-on: ubuntu-latest
+    env:
+      IS_PROD_DEPLOY: ${{ github.ref == 'refs/heads/develop' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -45,13 +47,13 @@ jobs:
       - run: npm install --global vercel@latest
 
       - name: Pull project settings
-        run: vercel pull --yes --environment=${{ github.ref == 'refs/heads/develop' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=${{ env.IS_PROD_DEPLOY == 'true' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PRE }}
 
       - name: Build
-        run: vercel build ${{ github.ref == 'refs/heads/develop' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build ${{ env.IS_PROD_DEPLOY == 'true' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PRE }}
@@ -61,10 +63,16 @@ jobs:
 
       - name: Deploy
         run: |
-          URL=$(vercel deploy --prebuilt ${{ github.ref == 'refs/heads/develop' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }})
-          echo "### PRE — ${{ github.ref == 'refs/heads/develop' && 'Production' || 'Preview' }}" >> $GITHUB_STEP_SUMMARY
-          echo "**URL:** $URL" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          DEPLOY_OUTPUT=$(vercel deploy --prebuilt ${{ env.IS_PROD_DEPLOY == 'true' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }})
+          URL=$(printf '%s\n' "$DEPLOY_OUTPUT" | grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | head -n 1)
+          if [ -z "$URL" ]; then
+            echo "Failed to extract deployment URL from Vercel output."
+            printf '%s\n' "$DEPLOY_OUTPUT"
+            exit 1
+          fi
+          echo "### PRE — ${{ env.IS_PROD_DEPLOY == 'true' && 'Production' || 'Preview' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**URL:** $URL" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Branch:** \`${{ github.ref_name }}\`" >> "$GITHUB_STEP_SUMMARY"
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PRE }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -82,10 +82,16 @@ jobs:
 
       - name: Deploy
         run: |
-          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
-          echo "### PRO — Preview" >> $GITHUB_STEP_SUMMARY
-          echo "**URL:** $URL" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          DEPLOY_OUTPUT=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          URL=$(printf '%s\n' "$DEPLOY_OUTPUT" | grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | head -n 1)
+          if [ -z "$URL" ]; then
+            echo "Failed to extract deployment URL from Vercel output."
+            printf '%s\n' "$DEPLOY_OUTPUT"
+            exit 1
+          fi
+          echo "### PRO — Preview" >> "$GITHUB_STEP_SUMMARY"
+          echo "**URL:** $URL" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Commit:** \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PROD }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -81,7 +81,11 @@ jobs:
           VITE_APP_ENV: preview
 
       - name: Deploy
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "### PRO — Preview" >> $GITHUB_STEP_SUMMARY
+          echo "**URL:** $URL" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_PROD }}


### PR DESCRIPTION
## Summary
- `develop` branch now deploys to PRE as **production** (updates the PRE main URL) instead of a temporary preview
- Feature branches still deploy to PRE as preview (unique URL per branch)
- Both PRE and PRO preview workflows now output the deployed URL in the GitHub Actions Job Summary (visible in the run summary tab)

## Test plan
- [ ] Push to `develop` → PRE main URL updated, URL visible in Actions summary
- [ ] Push to feature branch → PRE creates a unique preview URL, visible in Actions summary
- [ ] Push to `main` → PRO preview URL visible in Actions summary

🤖 Generated with [Claude Code](https://claude.ai/claude-code)