### PR TITLE
docs(ci): document CI/CD flow, gotchas and context rules

### DIFF
--- a/.claude/CONSTITUTION.md
+++ b/.claude/CONSTITUTION.md
@@ -157,7 +157,9 @@ Formato: `type(scope): descripción en inglés, presente imperativo`.
 
 ---
 
-## Art. 9 — Estrategia de ramas
+## Art. 9 — Estrategia de ramas y flujo de despliegue
+
+### Ramas
 
 - `main` → producción (Vercel PRO). Solo merges desde `develop` vía PR.
 - `develop` → pre-producción (Vercel PRE). Base de todo lo nuevo.
@@ -169,6 +171,32 @@ Formato: `type(scope): descripción en inglés, presente imperativo`.
 **Sub-tareas**: si una tarea sale de otra en curso, la rama hija se crea desde la rama actual (no desde `develop`). Se mergea de vuelta a la rama padre, no a `develop`.
 
 **Prohibido sin permiso**: `push --force`, `reset --hard`, `--no-verify`, merge sobre `main` directo.
+
+### Flujo de despliegue CI/CD
+
+| Evento | Workflow | Qué ocurre |
+|---|---|---|
+| Push a cualquier rama ≠ `main` y ≠ `develop` | `deploy-pre.yml` | Preview en Vercel PRE (URL temporal única) |
+| Push a `develop` | `deploy-pre.yml` | **Production en Vercel PRE** (actualiza URL principal de PRE) |
+| Push a `main` | `deploy-production.yml` | Preview en Vercel PRO + tag automático `v{fecha}-{hash}` |
+| `workflow_dispatch` manual con tag | `deploy-production-manual.yml` | **Production en Vercel PRO** (actualiza URL principal de PRO) |
+
+### Cómo desplegar a PRO (paso a paso)
+
+1. Mergea `develop → main` vía PR
+2. El CI crea automáticamente el tag (ej. `v20260418-ab6eda5`) y despliega preview en PRO
+3. Anota el tag: **GitHub → Actions → run del paso 2 → Job Summary**
+4. Ve a **GitHub → Actions → "Deploy Production (manual)" → Run workflow**
+5. Introduce el tag del paso 3 → confirma
+
+### Variables de entorno por entorno
+
+| Entorno | `VITE_APP_ENV` | Proyecto Vercel | Secrets usados |
+|---|---|---|---|
+| Feature branch | `preview` | `barber-dates-web-pre` | `INSFORGE_*_PRE` |
+| Develop (PRE production) | `preview` | `barber-dates-web-pre` | `INSFORGE_*_PRE` |
+| PRO preview | `preview` | `barber-dates-web-prod` | `INSFORGE_*_PROD` |
+| PRO production | `production` | `barber-dates-web-prod` | `INSFORGE_*_PROD` |
 
 ---
 

--- a/.claude/DECISIONS.md
+++ b/.claude/DECISIONS.md
@@ -49,6 +49,23 @@
 
 ---
 
+## ADR-005 — CI/CD con Vercel CLI (no GitHub Action) y deploy manual a PRO · 2026-04-18
+
+- **Estado**: accepted
+- **Contexto**: necesidad de controlar exactamente cuándo y qué se despliega en PRO, sin que Vercel auto-despliegue en cada push.
+- **Decisión**: usar Vercel CLI en GitHub Actions en lugar de la GitHub Action oficial de Vercel. Los despliegues a PRO production son siempre manuales vía `workflow_dispatch` con un tag específico.
+- **Alternativas consideradas**: Vercel auto-deploy desde GitHub (descartado: no permite controlar qué va a PRO ni cuándo). GitHub Action de Vercel (descartado: menos control sobre el environment y las variables).
+- **Consecuencias**: hay que deshabilitar los auto-deploys de Vercel en el dashboard (Settings → Git → "Ignored Build Step" = `exit 1`) en ambos proyectos. Sin eso, Vercel sigue desplegando en paralelo con su propia integración GitHub.
+
+## ADR-006 — `IS_PROD_DEPLOY` como env a nivel de job · 2026-04-18
+
+- **Estado**: accepted
+- **Contexto**: en `deploy-pre.yml`, la expresión `github.ref == 'refs/heads/develop'` se usaba 3 veces (pull, build, deploy).
+- **Decisión**: definir `IS_PROD_DEPLOY: ${{ github.ref == 'refs/heads/develop' }}` como `env` a nivel de job. Usarlo en steps como `${{ env.IS_PROD_DEPLOY == 'true' && '--prod' || '' }}`.
+- **Consecuencias**: el patrón `env.VAR == 'true' && 'X' || 'Y'` es el ternario idiomático de GitHub Actions cuando el valor proviene de un env de job (siempre string, no boolean).
+
+---
+
 ## ADR-003 — Constitution v1.1.0: quality gates migrados a pnpm
 
 - **Fecha**: 2026-04-17

--- a/.claude/KNOWLEDGE.md
+++ b/.claude/KNOWLEDGE.md
@@ -39,6 +39,29 @@ _(vacío — se irá llenando)_
 **Qué**: macOS incluye bash 3.2 por defecto. `declare -A` (arrays asociativos) es bash 4+. El script fallaba con `declare: -A: invalid option`.
 **Fix**: Reemplazado por cadena separada por espacios con `grep -qw` para comprobar membresía. Si en el futuro se necesitan arrays asociativos en scripts `.claude/`, usar bash 4 (Homebrew) o evitarlos.
 
+## CI/CD — Vercel + GitHub Actions
+
+### 2026-04-18 · deploy-pre.yml · el workflow se ejecuta desde la rama destino, no desde main
+
+**Qué**: `deploy-pre.yml` se ejecuta en ramas distintas de `main`. GitHub Actions usa el archivo de la **rama que recibe el push**. Si el fix está solo en `main`, `develop` sigue ejecutando la versión vieja.
+**Cómo detectarlo**: el log del CI muestra `vercel deploy --prebuilt` sin `--prod` aunque la rama sea develop.
+**Fix**: aplicar el cambio directamente a `develop` vía PR desde una rama `fix/`.
+
+### 2026-04-18 · Vercel CLI · `--prod` actualiza URL principal; sin él crea URL temporal
+
+**Qué**: `vercel deploy --prebuilt` sin `--prod` crea una URL única temporal. Con `--prod`, actualiza la URL de producción del proyecto.
+**Regla**: `vercel build --prod` + `vercel deploy --prebuilt --prod` siempre deben ir juntos.
+
+### 2026-04-18 · Vercel dashboard · auto-deploy de GitHub puede solaparse con el CI
+
+**Qué**: si el proyecto Vercel tiene la integración GitHub activa (por defecto), Vercel hace su propio deploy en paralelo al workflow de CI, generando despliegues duplicados.
+**Fix**: en cada proyecto Vercel → Settings → Git → "Ignored Build Step" → poner `exit 1`.
+
+### 2026-04-18 · Vercel CLI · URL de deploy mezclada con logs en stdout
+
+**Qué**: `vercel deploy --prebuilt` mezcla logs de progreso con la URL final en stdout. Capturar con `URL=$(vercel deploy ...)` puede capturar líneas de log en lugar de la URL.
+**Fix**: `grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | head -n 1`.
+
 ## Errores conocidos pendientes
 
 _(vacío)_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,24 @@
 
 ---
 
+## Regla de documentación: actualizar el contexto en el mismo commit
+
+> **Todo cambio relevante debe reflejarse en el contexto de Claude en el mismo paso en que ocurre.**
+
+Esto incluye:
+
+- **Nueva regla de negocio o cambio en una existente** → actualizar Art. 4 del Constitution.
+- **Nueva tabla, campo o relación** → actualizar Art. 5.
+- **Nueva ruta o cambio en auth** → actualizar Art. 6.
+- **Nueva variable de entorno** → actualizar Art. 13.
+- **Cambio en la estrategia de ramas o despliegue** → actualizar Art. 9.
+- **Gotcha, workaround o comportamiento sorprendente** → añadir entrada a `KNOWLEDGE.md`.
+- **Decisión arquitectónica** → añadir ADR a `DECISIONS.md`.
+
+**El objetivo**: que cualquier sesión futura de Claude pueda retomar el trabajo sin que el humano tenga que re-explicar decisiones ya tomadas. Si algo se implementó pero no se documentó, el conocimiento se pierde en el próximo `/compact`.
+
+---
+
 ## Regla fundamental: no hay código sin `/implement`
 
 > **Claude no modifica archivos de `src/` fuera del comando `/implement`.**


### PR DESCRIPTION
## Summary
- Art. 9 del Constitution: tabla completa del flujo CI/CD y pasos para desplegar a PRO
- DECISIONS.md: ADR-005 (Vercel CLI manual) y ADR-006 (patrón IS_PROD_DEPLOY)
- KNOWLEDGE.md: 4 gotchas del CI/CD (workflow desde rama destino, --prod, auto-deploy Vercel, extracción URL)
- CLAUDE.md: regla de documentación — todo cambio relevante debe documentarse en el mismo commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)