### PR TITLE
chore(deps): add InsForge dual-project setup and MCP configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,19 @@
-# Supabase / InsForge
-VITE_INSFORGE_URL=https://tu-proyecto.supabase.co
-VITE_INSFORGE_ANON_KEY=tu-anon-key-aqui
+# ─────────────────────────────────────────────────────────────────────────────
+# InsForge — dos proyectos (PRE y PROD)
+#
+# PRE  → gio-barber-shop-pre  (desarrollo + preview)
+#         ID:       770fe00d-3d16-40df-8e20-827ebc2eec61
+#         Base URL: https://99upfj9c.eu-central.insforge.app
+#
+# PROD → gio-barber-shop-prod (producción)
+#         ID:       ae9a7a66-84e5-40c2-be3b-c106fe2acb0b
+#         Base URL: https://pfzm89u2.eu-central.insforge.app
+#
+# Para desarrollo local usa los valores de PRE.
+# Los valores de PROD solo van en secrets de GitHub Actions (nunca en .env.local).
+# ─────────────────────────────────────────────────────────────────────────────
+VITE_INSFORGE_URL=https://99upfj9c.eu-central.insforge.app
+VITE_INSFORGE_ANON_KEY=tu-anon-key-de-pre-aqui
 
 # App
 VITE_APP_NAME="Gio Barber Shop"
@@ -10,7 +23,7 @@ VITE_APP_ENV=development
 VITE_GOOGLE_CLIENT_ID=tu-google-client-id
 
 # Mocks locales (solo desarrollo — copiar a .env.local, nunca commitear)
-# Activa MSW para interceptar peticiones sin Supabase real
+# Activa MSW para interceptar peticiones sin InsForge real
 VITE_USE_MOCKS=false
 # Rol del usuario fake al hacer login con el mock de auth: "client" | "admin"
 VITE_MOCK_ROLE=client

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,18 @@ Thumbs.db
 !.claude/tasks/.gitkeep
 
 PLAN_GIO_BARBER_SHOP.md
+# InsForge & AI agent skills
+.insforge
+.mcp.json
+.agent
+.agents
+.augment
+.claude
+.cline
+.github/copilot*
+.kilocode
+.qoder
+.qwen
+.roo
+.trae
+.windsurf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+---
+description: Instructions building apps with MCP
+globs: *
+alwaysApply: true
+---
+
+# InsForge SDK Documentation - Overview
+
+## What is InsForge?
+
+Backend-as-a-service (BaaS) platform providing:
+
+- **Database**: PostgreSQL with PostgREST API
+- **Authentication**: Email/password + OAuth (Google, GitHub)
+- **Storage**: File upload/download
+- **AI**: Chat completions and image generation (OpenAI-compatible)
+- **Functions**: Serverless function deployment
+- **Realtime**: WebSocket pub/sub (database + client events)
+
+## Installation
+
+The following is a step-by-step guide to installing and using the InsForge TypeScript SDK for Web applications. If you are building other types of applications, please refer to:
+- [Swift SDK documentation](/sdks/swift/overview) for iOS, macOS, tvOS, and watchOS applications.
+- [Kotlin SDK documentation](/sdks/kotlin/overview) for Android applications.
+- [REST API documentation](/sdks/rest/overview) for direct HTTP API access.
+
+### 🚨 CRITICAL: Follow these steps in order
+
+### Step 1: Download Template
+
+Use the `download-template` MCP tool to create a new project with your backend URL and anon key pre-configured.
+
+### Step 2: Install SDK
+
+```bash
+npm install @insforge/sdk@latest
+```
+
+### Step 3: Create SDK Client
+
+You must create a client instance using `createClient()` with your base URL and anon key:
+
+```javascript
+import { createClient } from '@insforge/sdk';
+
+const client = createClient({
+  baseUrl: 'https://your-app.region.insforge.app',  // Your InsForge backend URL
+  anonKey: 'your-anon-key-here'       // Get this from backend metadata
+});
+
+```
+
+**API BASE URL**: Your API base URL is `https://your-app.region.insforge.app`.
+
+## Getting Detailed Documentation
+
+### 🚨 CRITICAL: Always Fetch Documentation Before Writing Code
+
+InsForge provides official SDKs and REST APIs, use them to interact with InsForge services from your application code.
+
+- [TypeScript SDK](/sdks/typescript/overview) - JavaScript/TypeScript
+- [Swift SDK](/sdks/swift/overview) - iOS, macOS, tvOS, and watchOS
+- [Kotlin SDK](/sdks/kotlin/overview) - Android and Kotlin Multiplatform
+- [REST API](/sdks/rest/overview) - Direct HTTP API access
+
+Before writing or editing any InsForge integration code, you **MUST** call the `fetch-docs` or `fetch-sdk-docs` MCP tool to get the latest SDK documentation. This ensures you have accurate, up-to-date implementation patterns.
+
+### Use the InsForge `fetch-docs` MCP tool to get specific SDK documentation:
+
+Available documentation types:
+
+- `"instructions"` - Essential backend setup (START HERE)
+- `"real-time"` - Real-time pub/sub (database + client events) via WebSockets
+- `"db-sdk-typescript"` - Database operations with TypeScript SDK
+- **Authentication** - Choose based on implementation:
+  - `"auth-sdk-typescript"` - TypeScript SDK methods for custom auth flows
+  - `"auth-components-react"` - Pre-built auth UI for React+Vite (singlepage App)
+  - `"auth-components-react-router"` - Pre-built auth UI for React(Vite+React Router) (Multipage App)
+  - `"auth-components-nextjs"` - Pre-built auth UI for Nextjs (SSR App)
+- `"storage-sdk"` - File storage operations
+- `"functions-sdk"` - Serverless functions invocation
+- `"ai-integration-sdk"` - AI chat and image generation
+- `"real-time"` - Real-time pub/sub (database + client events) via WebSockets
+- `"deployment"` - Deploy frontend applications via MCP tool
+
+These documentations are mostly for TypeScript SDK. For other languages, you can also use `fetch-sdk-docs` mcp tool to get specific documentation.
+
+### Use the InsForge `fetch-sdk-docs` MCP tool to get specific SDK documentation
+
+You can fetch sdk documentation using the `fetch-sdk-docs` MCP tool with specific feature type and language.
+
+Available feature types:
+- db - Database operations
+- storage - File storage operations
+- functions - Serverless functions invocation
+- auth - User authentication
+- ai - AI chat and image generation
+- realtime - Real-time pub/sub (database + client events) via WebSockets
+
+Available languages:
+- typescript - JavaScript/TypeScript SDK
+- swift - Swift SDK (for iOS, macOS, tvOS, and watchOS)
+- kotlin - Kotlin SDK (for Android and JVM applications)
+- rest-api - REST API
+
+## When to Use SDK vs MCP Tools
+
+### Always SDK for Application Logic:
+
+- Authentication (register, login, logout, profiles)
+- Database CRUD (select, insert, update, delete)
+- Storage operations (upload, download files)
+- AI operations (chat, image generation)
+- Serverless function invocation
+
+### Use MCP Tools for Infrastructure:
+
+- Project scaffolding (`download-template`) - Download starter templates with InsForge integration
+- Backend setup and metadata (`get-backend-metadata`)
+- Database schema management (`run-raw-sql`, `get-table-schema`)
+- Storage bucket creation (`create-bucket`, `list-buckets`, `delete-bucket`)
+- Serverless function deployment (`create-function`, `update-function`, `delete-function`)
+- Frontend deployment (`create-deployment`) - Deploy frontend apps to InsForge hosting
+
+## Important Notes
+
+- For auth: use `auth-sdk` for custom UI, or framework-specific components for pre-built UI
+- SDK returns `{data, error}` structure for all operations
+- Database inserts require array format: `[{...}]`
+- Serverless functions have single endpoint (no subpaths)
+- Storage: Upload files to buckets, store URLs in database
+- AI operations are OpenAI-compatible
+- **EXTRA IMPORTANT**: Use Tailwind CSS 3.4 (do not upgrade to v4). Lock these dependencies in `package.json`

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "skills": {
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
+    },
+    "insforge": {
+      "source": "insforge/agent-skills",
+      "sourceType": "github",
+      "computedHash": "49ab9b9c520206022efc851c7dd4b81eed3d40428f123ed2c6213d5a127bde62"
+    },
+    "insforge-cli": {
+      "source": "insforge/agent-skills",
+      "sourceType": "github",
+      "computedHash": "9eefd32f8ed7195969d5fac788baa7ef99b452892e5ea9b00eb65e08a3ebece6"
+    },
+    "insforge-debug": {
+      "source": "insforge/agent-skills",
+      "sourceType": "github",
+      "computedHash": "f1f20f82cba657771767c563480f07efd3ab633566ccdcfccebce26039bbfce2"
+    },
+    "insforge-integrations": {
+      "source": "insforge/agent-skills",
+      "sourceType": "github",
+      "computedHash": "421b6eb1091930a437c223aae1d6547f3ee4d2e5cfef45e41a3e2b32a2c27f7e"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `.env.example` with PRE and PROD InsForge project URLs/IDs
- Add `AGENTS.md` with InsForge SDK instructions for Claude Code agents
- Add `skills-lock.json` (InsForge agent skills lock file)
- Update `.gitignore` to exclude `.mcp.json` (contains API keys)

**Projects configured:**
- PRE: `gio-barber-shop-pre` → `https://99upfj9c.eu-central.insforge.app`
- PROD: `gio-barber-shop-prod` → `https://pfzm89u2.eu-central.insforge.app`

## Test plan

- [ ] `.env.example` has correct PRE and PROD URLs
- [ ] `.mcp.json` is listed in `.gitignore` (no API keys leaked)
- [ ] `AGENTS.md` is readable and documents InsForge SDK usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)