### PR TITLE
feat(deps): add Vercel Analytics and Speed Insights

### DIFF
--- a/.claude/KNOWLEDGE.md
+++ b/.claude/KNOWLEDGE.md
@@ -62,6 +62,19 @@ _(vacío — se irá llenando)_
 **Qué**: `vercel deploy --prebuilt` mezcla logs de progreso con la URL final en stdout. Capturar con `URL=$(vercel deploy ...)` puede capturar líneas de log en lugar de la URL.
 **Fix**: `grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | head -n 1`.
 
+### 2026-04-18 · Vercel Analytics + Speed Insights · activación en dashboard obligatoria
+
+**Qué**: Los componentes `<Analytics />` y `<SpeedInsights />` de `@vercel/analytics` y `@vercel/speed-insights` están montados en `src/main.tsx`. Sin embargo, el dashboard de Vercel permanece vacío hasta que Analytics se active manualmente por proyecto.
+
+**Pasos para activar** (hacer una sola vez por proyecto):
+1. Vercel Dashboard → proyecto `barber-dates-web-pre` → pestaña **Analytics** → **Enable**
+2. Vercel Dashboard → proyecto `barber-dates-web-prod` → pestaña **Analytics** → **Enable**
+3. Para Speed Insights: mismo flujo, pestaña **Speed Insights** → **Enable**
+
+**En local**: los componentes se montan pero no envían datos — solo funcionan en dominios `*.vercel.app` o dominios custom configurados en Vercel.
+
+**GDPR**: Vercel Analytics no usa cookies ni almacena IPs completas. Cumple sin banner de cookies en España bajo el marco RGPD actual.
+
 ## Errores conocidos pendientes
 
 _(vacío)_

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-virtual": "^3.13.23",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.13.23
         version: 3.13.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.5)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1074,6 +1080,61 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.2':
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -3214,6 +3275,14 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
+
+  '@vercel/analytics@2.0.1(react@19.2.5)':
+    optionalDependencies:
+      react: 19.2.5
+
+  '@vercel/speed-insights@2.0.0(react@19.2.5)':
+    optionalDependencies:
+      react: 19.2.5
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { HelmetProvider } from 'react-helmet-async'
+import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/react'
 import './styles/globals.css'
 import App from './App.tsx'
 
@@ -30,6 +32,8 @@ async function bootstrap() {
           </BrowserRouter>
         </QueryClientProvider>
       </HelmetProvider>
+      <Analytics />
+      <SpeedInsights />
     </StrictMode>,
   )
 }


### PR DESCRIPTION
## Summary

- Instala `@vercel/analytics` y `@vercel/speed-insights`
- Monta `<Analytics />` y `<SpeedInsights />` en el root de React para habilitar tracking de page views y Core Web Vitals
- Documenta los pasos de activación manual en el dashboard de Vercel (PRE y PRO) en `KNOWLEDGE.md`

Closes #12

## Test plan

- [ ] Verificar en Vercel Dashboard → `barber-dates-web-pre` → **Analytics** → Enable
- [ ] Verificar en Vercel Dashboard → `barber-dates-web-prod` → **Analytics** → Enable
- [ ] Mismo para **Speed Insights** en ambos proyectos
- [ ] Confirmar que el dashboard muestra datos tras las primeras visitas post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)