### PR TITLE
feat(agentic): nuevo comando /test — E2E visual con Playwright MCP

### DIFF
--- a/.claude/CONSTITUTION.md
+++ b/.claude/CONSTITUTION.md
@@ -157,7 +157,9 @@ Formato: `type(scope): descripción en inglés, presente imperativo`.
 
 ---
 
-## Art. 9 — Estrategia de ramas
+## Art. 9 — Estrategia de ramas y flujo de despliegue
+
+### Ramas
 
 - `main` → producción (Vercel PRO). Solo merges desde `develop` vía PR.
 - `develop` → pre-producción (Vercel PRE). Base de todo lo nuevo.
@@ -169,6 +171,32 @@ Formato: `type(scope): descripción en inglés, presente imperativo`.
 **Sub-tareas**: si una tarea sale de otra en curso, la rama hija se crea desde la rama actual (no desde `develop`). Se mergea de vuelta a la rama padre, no a `develop`.
 
 **Prohibido sin permiso**: `push --force`, `reset --hard`, `--no-verify`, merge sobre `main` directo.
+
+### Flujo de despliegue CI/CD
+
+| Evento | Workflow | Qué ocurre |
+|---|---|---|
+| Push a cualquier rama ≠ `main` y ≠ `develop` | `deploy-pre.yml` | Preview en Vercel PRE (URL temporal única) |
+| Push a `develop` | `deploy-pre.yml` | **Production en Vercel PRE** (actualiza URL principal de PRE) |
+| Push a `main` | `deploy-production.yml` | Preview en Vercel PRO + tag automático `v{fecha}-{hash}` |
+| `workflow_dispatch` manual con tag | `deploy-production-manual.yml` | **Production en Vercel PRO** (actualiza URL principal de PRO) |
+
+### Cómo desplegar a PRO (paso a paso)
+
+1. Mergea `develop → main` vía PR
+2. El CI crea automáticamente el tag (ej. `v20260418-ab6eda5`) y despliega preview en PRO
+3. Anota el tag: **GitHub → Actions → run del paso 2 → Job Summary**
+4. Ve a **GitHub → Actions → "Deploy Production (manual)" → Run workflow**
+5. Introduce el tag del paso 3 → confirma
+
+### Variables de entorno por entorno
+
+| Entorno | `VITE_APP_ENV` | Proyecto Vercel | Secrets usados |
+|---|---|---|---|
+| Feature branch | `preview` | `barber-dates-web-pre` | `INSFORGE_*_PRE` |
+| Develop (PRE production) | `preview` | `barber-dates-web-pre` | `INSFORGE_*_PRE` |
+| PRO preview | `preview` | `barber-dates-web-prod` | `INSFORGE_*_PROD` |
+| PRO production | `production` | `barber-dates-web-prod` | `INSFORGE_*_PROD` |
 
 ---
 

--- a/.claude/DECISIONS.md
+++ b/.claude/DECISIONS.md
@@ -49,6 +49,23 @@
 
 ---
 
+## ADR-005 — CI/CD con Vercel CLI (no GitHub Action) y deploy manual a PRO · 2026-04-18
+
+- **Estado**: accepted
+- **Contexto**: necesidad de controlar exactamente cuándo y qué se despliega en PRO, sin que Vercel auto-despliegue en cada push.
+- **Decisión**: usar Vercel CLI en GitHub Actions en lugar de la GitHub Action oficial de Vercel. Los despliegues a PRO production son siempre manuales vía `workflow_dispatch` con un tag específico.
+- **Alternativas consideradas**: Vercel auto-deploy desde GitHub (descartado: no permite controlar qué va a PRO ni cuándo). GitHub Action de Vercel (descartado: menos control sobre el environment y las variables).
+- **Consecuencias**: hay que deshabilitar los auto-deploys de Vercel en el dashboard (Settings → Git → "Ignored Build Step" = `exit 1`) en ambos proyectos. Sin eso, Vercel sigue desplegando en paralelo con su propia integración GitHub.
+
+## ADR-006 — `IS_PROD_DEPLOY` como env a nivel de job · 2026-04-18
+
+- **Estado**: accepted
+- **Contexto**: en `deploy-pre.yml`, la expresión `github.ref == 'refs/heads/develop'` se usaba 3 veces (pull, build, deploy).
+- **Decisión**: definir `IS_PROD_DEPLOY: ${{ github.ref == 'refs/heads/develop' }}` como `env` a nivel de job. Usarlo en steps como `${{ env.IS_PROD_DEPLOY == 'true' && '--prod' || '' }}`.
+- **Consecuencias**: el patrón `env.VAR == 'true' && 'X' || 'Y'` es el ternario idiomático de GitHub Actions cuando el valor proviene de un env de job (siempre string, no boolean).
+
+---
+
 ## ADR-003 — Constitution v1.1.0: quality gates migrados a pnpm
 
 - **Fecha**: 2026-04-17

--- a/.claude/KNOWLEDGE.md
+++ b/.claude/KNOWLEDGE.md
@@ -62,6 +62,19 @@ _(vacío — se irá llenando)_
 **Qué**: `vercel deploy --prebuilt` mezcla logs de progreso con la URL final en stdout. Capturar con `URL=$(vercel deploy ...)` puede capturar líneas de log en lugar de la URL.
 **Fix**: `grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | head -n 1`.
 
+### 2026-04-18 · Vercel Analytics + Speed Insights · activación en dashboard obligatoria
+
+**Qué**: Los componentes `<Analytics />` y `<SpeedInsights />` de `@vercel/analytics` y `@vercel/speed-insights` están montados en `src/main.tsx`. Sin embargo, el dashboard de Vercel permanece vacío hasta que Analytics se active manualmente por proyecto.
+
+**Pasos para activar** (hacer una sola vez por proyecto):
+1. Vercel Dashboard → proyecto `barber-dates-web-pre` → pestaña **Analytics** → **Enable**
+2. Vercel Dashboard → proyecto `barber-dates-web-prod` → pestaña **Analytics** → **Enable**
+3. Para Speed Insights: mismo flujo, pestaña **Speed Insights** → **Enable**
+
+**En local**: los componentes se montan pero no envían datos — solo funcionan en dominios `*.vercel.app` o dominios custom configurados en Vercel.
+
+**GDPR**: Vercel Analytics no usa cookies ni almacena IPs completas. Cumple sin banner de cookies en España bajo el marco RGPD actual.
+
 ## Errores conocidos pendientes
 
 _(vacío)_

--- a/.claude/KNOWLEDGE.md
+++ b/.claude/KNOWLEDGE.md
@@ -39,6 +39,29 @@ _(vacío — se irá llenando)_
 **Qué**: macOS incluye bash 3.2 por defecto. `declare -A` (arrays asociativos) es bash 4+. El script fallaba con `declare: -A: invalid option`.
 **Fix**: Reemplazado por cadena separada por espacios con `grep -qw` para comprobar membresía. Si en el futuro se necesitan arrays asociativos en scripts `.claude/`, usar bash 4 (Homebrew) o evitarlos.
 
+## CI/CD — Vercel + GitHub Actions
+
+### 2026-04-18 · deploy-pre.yml · el workflow se ejecuta desde la rama destino, no desde main
+
+**Qué**: `deploy-pre.yml` se ejecuta en ramas distintas de `main`. GitHub Actions usa el archivo de la **rama que recibe el push**. Si el fix está solo en `main`, `develop` sigue ejecutando la versión vieja.
+**Cómo detectarlo**: el log del CI muestra `vercel deploy --prebuilt` sin `--prod` aunque la rama sea develop.
+**Fix**: aplicar el cambio directamente a `develop` vía PR desde una rama `fix/`.
+
+### 2026-04-18 · Vercel CLI · `--prod` actualiza URL principal; sin él crea URL temporal
+
+**Qué**: `vercel deploy --prebuilt` sin `--prod` crea una URL única temporal. Con `--prod`, actualiza la URL de producción del proyecto.
+**Regla**: `vercel build --prod` + `vercel deploy --prebuilt --prod` siempre deben ir juntos.
+
+### 2026-04-18 · Vercel dashboard · auto-deploy de GitHub puede solaparse con el CI
+
+**Qué**: si el proyecto Vercel tiene la integración GitHub activa (por defecto), Vercel hace su propio deploy en paralelo al workflow de CI, generando despliegues duplicados.
+**Fix**: en cada proyecto Vercel → Settings → Git → "Ignored Build Step" → poner `exit 1`.
+
+### 2026-04-18 · Vercel CLI · URL de deploy mezclada con logs en stdout
+
+**Qué**: `vercel deploy --prebuilt` mezcla logs de progreso con la URL final en stdout. Capturar con `URL=$(vercel deploy ...)` puede capturar líneas de log en lugar de la URL.
+**Fix**: `grep -Eo 'https://[^[:space:]]+\.vercel\.app[^[:space:]]*' | head -n 1`.
+
 ## Errores conocidos pendientes
 
 _(vacío)_

--- a/.claude/commands/done.md
+++ b/.claude/commands/done.md
@@ -75,6 +75,32 @@ Nunca tocar CONSTITUTION.md sin confirmación explícita (Art. 14).
 - `STATE.md` → status `done`.
 - `LOG.md` → entrada `done` con timestamp y resumen.
 
+### 6b. Mergear la rama base en la rama actual
+
+Antes de proponer la PR, traer los últimos cambios de la rama destino para que la rama esté al día y no haya conflictos en el merge:
+
+```bash
+BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo "develop")
+git fetch origin
+git merge origin/$BASE
+```
+
+Si hay conflictos → resolverlos y hacer commit antes de continuar. No proponer la PR con conflictos sin resolver.
+
+### 6c. Verificar estado de PR existente
+
+Comprobar si ya existe una PR para esta rama antes de proponer crear una nueva:
+
+```bash
+gh pr list --head $(git branch --show-current) --state all --json number,state,title
+```
+
+Según el resultado:
+
+- **Sin resultados** → proceder al paso 7 normalmente con `gh pr create`.
+- **PR OPEN** → no crear nueva; comunicar al usuario: `"La PR #N ya está abierta y lista para merge."` No proponer `gh pr create`.
+- **PR MERGED o CLOSED** → informar al usuario del estado y preguntar: `"La PR #N ya fue mergeada/cerrada. ¿Quieres abrir una PR nueva para esta iteración?"`
+
 ### 7. Propuesta de cierre
 
 Solo cuando los pasos 2–5 están completos:

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -37,7 +37,7 @@ Ejemplos:
 ### 2. Crear la rama
 
 ```bash
-git checkout <base> && git pull
+git checkout <base> && git pull origin <base>
 git checkout -b feature/<slug>
 ```
 

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,220 @@
+# Comando: /test
+
+Lanza un subagente que abre Chromium, navega la app y verifica que los flujos principales funcionan visualmente.
+Genera `TEST.md` con veredicto PASS/FAIL por flujo.
+
+**Posición en el ciclo de vida**: después de `/review`, antes de `/done`.
+
+```
+/implement → /change (ajustes) → /review → /test → /done
+```
+
+## Uso
+
+```
+/test           # testea en local (mock), flujos por defecto o los del README
+/test --pre     # testea contra el entorno PRE (InsForge real, pide credenciales)
+```
+
+## Precondiciones
+
+- El plan está en estado `approved` o `done` (todos los pasos implementados).
+- `/review` ya se ha ejecutado y no hay bloqueos abiertos.
+- El MCP de Playwright está configurado en `~/.claude/settings.json`:
+  ```json
+  "playwright": {
+    "command": "npx",
+    "args": ["@playwright/mcp@latest"]
+  }
+  ```
+  Si no está → reportar error y detener. Indicar al usuario que debe añadirlo.
+
+## Lo que debes hacer
+
+### 1. Identificar tarea activa y modo
+
+```bash
+bash .claude/scripts/active-task.sh
+```
+
+Leer el argumento del comando:
+- Sin `--pre` → **modo local** (servidor de desarrollo, todo mockeado).
+- Con `--pre` → **modo PRE** (backend InsForge real, requiere credenciales).
+
+### 2. Credenciales (solo modo PRE)
+
+Si el modo es `--pre`, preguntar al usuario:
+- Email de la cuenta de test en InsForge PRE
+- Contraseña de esa cuenta
+
+Guardar en variables temporales de sesión. **No escribir en ningún archivo.**
+
+### 3. Detectar o levantar el servidor de desarrollo
+
+```bash
+curl -s --max-time 2 http://localhost:5173 -o /dev/null -w "%{http_code}"
+```
+
+- Si devuelve `200` (o cualquier código HTTP) → servidor ya corre, continuar.
+- Si falla (exit code distinto de 0 o timeout) → levantar en background:
+
+```bash
+pnpm dev &
+DEV_SERVER_PID=$!
+```
+
+Luego hacer polling hasta que responda (máx 30 intentos × 1 s = 30 s):
+
+```bash
+for i in $(seq 1 30); do
+  curl -s --max-time 1 http://localhost:5173 -o /dev/null && break
+  sleep 1
+done
+```
+
+Si no responde tras 30 s → reportar error al usuario y terminar.
+
+Anotar si el servidor fue levantado por nosotros (`DEV_SERVER_STARTED=true`) para apagarlo al final.
+
+### 4. Determinar flujos a testear
+
+Buscar sección `## Flujos a testear` en el `README.md` de la tarea activa:
+
+```bash
+bash .claude/scripts/section.sh .claude/tasks/<TASK-ID>/README.md "Flujos a testear"
+```
+
+Si la sección existe → usar esos flujos.
+Si no existe → usar los **flujos por defecto** (ver más abajo).
+
+### 5. Lanzar subagente con Playwright
+
+Crear carpeta de capturas:
+
+```bash
+mkdir -p .claude/tasks/<TASK-ID>/screenshots
+```
+
+Lanzar subagente con el siguiente prompt, adaptado al modo (local/PRE) y a los flujos determinados:
+
+```
+Agent({
+  prompt: "Eres un tester QA. Usa el MCP de Playwright para navegar la app en http://localhost:5173 y verificar los siguientes flujos.
+
+  Modo: <local | PRE>
+  <Si PRE>: Las credenciales de login son: email=<email>, password=<password></Si PRE>
+  <Si local>: La app usa mocks — no hay login real. Navega directamente a las rutas.
+
+  Para cada flujo:
+  1. Navega a la URL indicada.
+  2. Realiza las acciones descritas.
+  3. Toma un screenshot con browser_screenshot y guárdalo en .claude/tasks/<TASK-ID>/screenshots/<N>-<slug>.png
+  4. Indica si el flujo pasó ✅ o falló ❌ y por qué.
+
+  Flujos a testear:
+  <lista de flujos con pasos concretos>
+
+  Al terminar, devuelve un JSON con este formato:
+  {
+    'environment': 'local | PRE',
+    'url': 'http://localhost:5173',
+    'flows': [
+      { 'id': 'F-1', 'name': '...', 'result': 'PASS | FAIL', 'notes': '...', 'screenshot': 'screenshots/...' },
+      ...
+    ],
+    'verdict': 'PASS | FAIL',
+    'summary': '...'
+  }"
+})
+```
+
+### 6. Escribir TEST.md
+
+Con el resultado del subagente, generar `.claude/tasks/<TASK-ID>/TEST.md`:
+
+```markdown
+# TEST — TASK-<ID> · YYYY-MM-DD HH:mm
+
+## Entorno
+
+- **URL**: http://localhost:5173
+- **Modo**: local (mock) | PRE (InsForge real)
+- **Browser**: Chromium (headed)
+- **Servidor**: levantado por /test | ya estaba corriendo
+
+## Flujos
+
+### F-1 — <nombre> ✅/❌
+
+<descripción del resultado>
+Screenshot: `screenshots/01-<slug>.png`
+
+### F-2 — <nombre> ✅/❌
+
+<descripción del resultado>
+Screenshot: `screenshots/02-<slug>.png`
+
+...
+
+## Veredicto: PASS | FAIL
+
+- Flujos pasados: X/Y
+- Flujos fallidos: [F-2 — nombre, ...]
+```
+
+### 7. Limpiar servidor (si aplica)
+
+Si `DEV_SERVER_STARTED=true`:
+
+```bash
+kill $DEV_SERVER_PID 2>/dev/null || true
+```
+
+### 8. Reportar al usuario
+
+**Si veredicto = PASS**:
+```
+✅ /test PASS — X/X flujos superados
+   TEST.md escrito en .claude/tasks/<TASK-ID>/TEST.md
+
+Siguiente: /done para proponer el PR.
+```
+
+**Si veredicto = FAIL**:
+```
+❌ /test FAIL — X/Y flujos superados
+   Fallaron: F-N (nombre), ...
+   Ver TEST.md para capturas y detalles.
+
+Usa /change <descripción> para corregir antes de /done.
+```
+
+---
+
+## Flujos por defecto
+
+Se usan cuando el README de la tarea no define `## Flujos a testear`.
+
+| ID | Nombre | Pasos |
+|---|---|---|
+| F-1 | App carga | Navegar a `/` → sin error de pantalla blanca ni consola roja |
+| F-2 | Ruta principal accesible | Navegar a la ruta principal de la feature → componente visible |
+| F-3 | Login (solo PRE) | Ir a `/login` → rellenar email/password → submit → redirige al dashboard |
+| F-4 | Ver citas (solo PRE, tras F-3) | Navegar a `/appointments` → lista visible, sin error |
+| F-5 | Logout (solo PRE, tras F-3) | Click en logout → redirige a `/login` |
+
+Para features que no tienen flujos de usuario obvios (chores, infra, ci), el subagente solo ejecuta F-1.
+
+---
+
+## Nota sobre el modo headed vs headless
+
+Por defecto el MCP de Playwright abre una ventana de Chromium visible.
+Si necesitas ejecutarlo sin ventana (ej. en un servidor sin display), edita `~/.claude/settings.json`:
+
+```json
+"playwright": {
+  "command": "npx",
+  "args": ["@playwright/mcp@latest", "--headless"]
+}
+```

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -12,8 +12,17 @@ Genera `TEST.md` con veredicto PASS/FAIL por flujo.
 ## Uso
 
 ```
-/test           # testea en local (mock), flujos por defecto o los del README
-/test --pre     # testea contra el entorno PRE (InsForge real, pide credenciales)
+/test                              # flujos del README o por defecto (local/mock)
+/test <descripción libre>          # testea exactamente lo que describes
+/test --pre                        # flujos del README o por defecto (PRE real)
+/test --pre <descripción libre>    # testea lo que describes contra PRE
+```
+
+Ejemplos:
+```
+/test login y registro
+/test que se puede reservar una cita y cancelarla
+/test --pre el flujo completo de puntos de fidelidad
 ```
 
 ## Precondiciones
@@ -78,14 +87,29 @@ Anotar si el servidor fue levantado por nosotros (`DEV_SERVER_STARTED=true`) par
 
 ### 4. Determinar flujos a testear
 
-Buscar sección `## Flujos a testear` en el `README.md` de la tarea activa:
+Prioridad decreciente — usar el primer nivel que aplique:
+
+**Nivel 0 — argumento del comando (mayor prioridad)**
+
+Si el usuario pasó texto libre al invocar `/test` (ej. `/test login y reserva de cita`):
+→ usar ese texto directamente como instrucción para el subagente.
+→ saltar los niveles 1 y 2.
+
+El subagente recibirá: *"El usuario quiere testear: `<texto del argumento>`. Diseña y ejecuta los pasos necesarios para verificarlo."*
+
+**Nivel 1 — sección en el README de la tarea**
+
+Si no hay argumento, buscar sección `## Flujos a testear` en el `README.md` de la tarea activa:
 
 ```bash
 bash .claude/scripts/section.sh .claude/tasks/<TASK-ID>/README.md "Flujos a testear"
 ```
 
 Si la sección existe → usar esos flujos.
-Si no existe → usar los **flujos por defecto** (ver más abajo).
+
+**Nivel 2 — flujos por defecto (fallback)**
+
+Si tampoco existe la sección → usar los **flujos por defecto** (ver más abajo).
 
 ### 5. Lanzar subagente con Playwright
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,7 +58,10 @@
       "Bash(which *)",
       "Bash(pwd)",
       "Bash(chmod +x *)",
-      "Bash(jq *)"
+      "Bash(jq *)",
+      "Bash(curl *)",
+      "Bash(kill *)",
+      "Bash(lsof *)"
     ],
     "deny": [
       "Bash(git push --force*)",

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,19 @@
-# Supabase / InsForge
-VITE_INSFORGE_URL=https://tu-proyecto.supabase.co
-VITE_INSFORGE_ANON_KEY=tu-anon-key-aqui
+# ─────────────────────────────────────────────────────────────────────────────
+# InsForge — dos proyectos (PRE y PROD)
+#
+# PRE  → gio-barber-shop-pre  (desarrollo + preview)
+#         ID:       770fe00d-3d16-40df-8e20-827ebc2eec61
+#         Base URL: https://99upfj9c.eu-central.insforge.app
+#
+# PROD → gio-barber-shop-prod (producción)
+#         ID:       ae9a7a66-84e5-40c2-be3b-c106fe2acb0b
+#         Base URL: https://pfzm89u2.eu-central.insforge.app
+#
+# Para desarrollo local usa los valores de PRE.
+# Los valores de PROD solo van en secrets de GitHub Actions (nunca en .env.local).
+# ─────────────────────────────────────────────────────────────────────────────
+VITE_INSFORGE_URL=https://99upfj9c.eu-central.insforge.app
+VITE_INSFORGE_ANON_KEY=tu-anon-key-de-pre-aqui
 
 # App
 VITE_APP_NAME="Gio Barber Shop"
@@ -10,7 +23,7 @@ VITE_APP_ENV=development
 VITE_GOOGLE_CLIENT_ID=tu-google-client-id
 
 # Mocks locales (solo desarrollo — copiar a .env.local, nunca commitear)
-# Activa MSW para interceptar peticiones sin Supabase real
+# Activa MSW para interceptar peticiones sin InsForge real
 VITE_USE_MOCKS=false
 # Rol del usuario fake al hacer login con el mock de auth: "client" | "admin"
 VITE_MOCK_ROLE=client

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,18 @@ Thumbs.db
 !.claude/tasks/.gitkeep
 
 PLAN_GIO_BARBER_SHOP.md
+# InsForge & AI agent skills
+.insforge
+.mcp.json
+.agent
+.agents
+.augment
+.claude
+.cline
+.github/copilot*
+.kilocode
+.qoder
+.qwen
+.roo
+.trae
+.windsurf

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+---
+description: Instructions building apps with MCP
+globs: *
+alwaysApply: true
+---
+
+# InsForge SDK Documentation - Overview
+
+## What is InsForge?
+
+Backend-as-a-service (BaaS) platform providing:
+
+- **Database**: PostgreSQL with PostgREST API
+- **Authentication**: Email/password + OAuth (Google, GitHub)
+- **Storage**: File upload/download
+- **AI**: Chat completions and image generation (OpenAI-compatible)
+- **Functions**: Serverless function deployment
+- **Realtime**: WebSocket pub/sub (database + client events)
+
+## Installation
+
+The following is a step-by-step guide to installing and using the InsForge TypeScript SDK for Web applications. If you are building other types of applications, please refer to:
+- [Swift SDK documentation](/sdks/swift/overview) for iOS, macOS, tvOS, and watchOS applications.
+- [Kotlin SDK documentation](/sdks/kotlin/overview) for Android applications.
+- [REST API documentation](/sdks/rest/overview) for direct HTTP API access.
+
+### 🚨 CRITICAL: Follow these steps in order
+
+### Step 1: Download Template
+
+Use the `download-template` MCP tool to create a new project with your backend URL and anon key pre-configured.
+
+### Step 2: Install SDK
+
+```bash
+npm install @insforge/sdk@latest
+```
+
+### Step 3: Create SDK Client
+
+You must create a client instance using `createClient()` with your base URL and anon key:
+
+```javascript
+import { createClient } from '@insforge/sdk';
+
+const client = createClient({
+  baseUrl: 'https://your-app.region.insforge.app',  // Your InsForge backend URL
+  anonKey: 'your-anon-key-here'       // Get this from backend metadata
+});
+
+```
+
+**API BASE URL**: Your API base URL is `https://your-app.region.insforge.app`.
+
+## Getting Detailed Documentation
+
+### 🚨 CRITICAL: Always Fetch Documentation Before Writing Code
+
+InsForge provides official SDKs and REST APIs, use them to interact with InsForge services from your application code.
+
+- [TypeScript SDK](/sdks/typescript/overview) - JavaScript/TypeScript
+- [Swift SDK](/sdks/swift/overview) - iOS, macOS, tvOS, and watchOS
+- [Kotlin SDK](/sdks/kotlin/overview) - Android and Kotlin Multiplatform
+- [REST API](/sdks/rest/overview) - Direct HTTP API access
+
+Before writing or editing any InsForge integration code, you **MUST** call the `fetch-docs` or `fetch-sdk-docs` MCP tool to get the latest SDK documentation. This ensures you have accurate, up-to-date implementation patterns.
+
+### Use the InsForge `fetch-docs` MCP tool to get specific SDK documentation:
+
+Available documentation types:
+
+- `"instructions"` - Essential backend setup (START HERE)
+- `"real-time"` - Real-time pub/sub (database + client events) via WebSockets
+- `"db-sdk-typescript"` - Database operations with TypeScript SDK
+- **Authentication** - Choose based on implementation:
+  - `"auth-sdk-typescript"` - TypeScript SDK methods for custom auth flows
+  - `"auth-components-react"` - Pre-built auth UI for React+Vite (singlepage App)
+  - `"auth-components-react-router"` - Pre-built auth UI for React(Vite+React Router) (Multipage App)
+  - `"auth-components-nextjs"` - Pre-built auth UI for Nextjs (SSR App)
+- `"storage-sdk"` - File storage operations
+- `"functions-sdk"` - Serverless functions invocation
+- `"ai-integration-sdk"` - AI chat and image generation
+- `"real-time"` - Real-time pub/sub (database + client events) via WebSockets
+- `"deployment"` - Deploy frontend applications via MCP tool
+
+These documentations are mostly for TypeScript SDK. For other languages, you can also use `fetch-sdk-docs` mcp tool to get specific documentation.
+
+### Use the InsForge `fetch-sdk-docs` MCP tool to get specific SDK documentation
+
+You can fetch sdk documentation using the `fetch-sdk-docs` MCP tool with specific feature type and language.
+
+Available feature types:
+- db - Database operations
+- storage - File storage operations
+- functions - Serverless functions invocation
+- auth - User authentication
+- ai - AI chat and image generation
+- realtime - Real-time pub/sub (database + client events) via WebSockets
+
+Available languages:
+- typescript - JavaScript/TypeScript SDK
+- swift - Swift SDK (for iOS, macOS, tvOS, and watchOS)
+- kotlin - Kotlin SDK (for Android and JVM applications)
+- rest-api - REST API
+
+## When to Use SDK vs MCP Tools
+
+### Always SDK for Application Logic:
+
+- Authentication (register, login, logout, profiles)
+- Database CRUD (select, insert, update, delete)
+- Storage operations (upload, download files)
+- AI operations (chat, image generation)
+- Serverless function invocation
+
+### Use MCP Tools for Infrastructure:
+
+- Project scaffolding (`download-template`) - Download starter templates with InsForge integration
+- Backend setup and metadata (`get-backend-metadata`)
+- Database schema management (`run-raw-sql`, `get-table-schema`)
+- Storage bucket creation (`create-bucket`, `list-buckets`, `delete-bucket`)
+- Serverless function deployment (`create-function`, `update-function`, `delete-function`)
+- Frontend deployment (`create-deployment`) - Deploy frontend apps to InsForge hosting
+
+## Important Notes
+
+- For auth: use `auth-sdk` for custom UI, or framework-specific components for pre-built UI
+- SDK returns `{data, error}` structure for all operations
+- Database inserts require array format: `[{...}]`
+- Serverless functions have single endpoint (no subpaths)
+- Storage: Upload files to buckets, store URLs in database
+- AI operations are OpenAI-compatible
+- **EXTRA IMPORTANT**: Use Tailwind CSS 3.4 (do not upgrade to v4). Lock these dependencies in `package.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
 /implement       → código paso a paso (un commit por paso)
 /change <qué>    → corrección sin saltar a código (para, espera /implement)
 /review          → subagente audita + quality gates
+/test            → subagente abre browser y testea flujos de la app (E2E visual)
 /done            → propone PR (confirmación antes de push)
 ```
 
@@ -140,6 +141,7 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
 | `/next`                           | Implementación | Atajo para `/implement next`                         |
 | `/change <qué>`                   | Corrección     | Analiza ajuste → propone plan → espera `/implement`  |
 | `/review`                         | Review         | Subagente + quality gates + criterios                |
+| `/test [--pre]`                   | Test visual    | Subagente abre Chromium y recorre flujos de la app   |
 | `/done`                           | Cierre         | Propone PR (confirmación antes de push)              |
 
 ### Gestión de sesión y tarea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,24 @@
 
 ---
 
+## Regla de documentación: actualizar el contexto en el mismo commit
+
+> **Todo cambio relevante debe reflejarse en el contexto de Claude en el mismo paso en que ocurre.**
+
+Esto incluye:
+
+- **Nueva regla de negocio o cambio en una existente** → actualizar Art. 4 del Constitution.
+- **Nueva tabla, campo o relación** → actualizar Art. 5.
+- **Nueva ruta o cambio en auth** → actualizar Art. 6.
+- **Nueva variable de entorno** → actualizar Art. 13.
+- **Cambio en la estrategia de ramas o despliegue** → actualizar Art. 9.
+- **Gotcha, workaround o comportamiento sorprendente** → añadir entrada a `KNOWLEDGE.md`.
+- **Decisión arquitectónica** → añadir ADR a `DECISIONS.md`.
+
+**El objetivo**: que cualquier sesión futura de Claude pueda retomar el trabajo sin que el humano tenga que re-explicar decisiones ya tomadas. Si algo se implementó pero no se documentó, el conocimiento se pierde en el próximo `/compact`.
+
+---
+
 ## Regla fundamental: no hay código sin `/implement`
 
 > **Claude no modifica archivos de `src/` fuera del comando `/implement`.**

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,6 +18,7 @@ export default {
         'ci',
         'seo',
         'readme',
+        'agentic',
       ],
     ],
     'subject-max-length': [2, 'always', 72],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-query": "^5.99.0",
     "@tanstack/react-virtual": "^3.13.23",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       '@tanstack/react-virtual':
         specifier: ^3.13.23
         version: 3.13.23(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@19.2.5)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.5)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1074,6 +1080,61 @@ packages:
   '@typescript-eslint/visitor-keys@8.58.2':
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -3214,6 +3275,14 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
+
+  '@vercel/analytics@2.0.1(react@19.2.5)':
+    optionalDependencies:
+      react: 19.2.5
+
+  '@vercel/speed-insights@2.0.0(react@19.2.5)':
+    optionalDependencies:
+      react: 19.2.5
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "skills": {
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
+    },
+    "insforge": {
+      "source": "insforge/agent-skills",
+      "sourceType": "github",
+      "computedHash": "49ab9b9c520206022efc851c7dd4b81eed3d40428f123ed2c6213d5a127bde62"
+    },
+    "insforge-cli": {
+      "source": "insforge/agent-skills",
+      "sourceType": "github",
+      "computedHash": "9eefd32f8ed7195969d5fac788baa7ef99b452892e5ea9b00eb65e08a3ebece6"
+    },
+    "insforge-debug": {
+      "source": "insforge/agent-skills",
+      "sourceType": "github",
+      "computedHash": "f1f20f82cba657771767c563480f07efd3ab633566ccdcfccebce26039bbfce2"
+    },
+    "insforge-integrations": {
+      "source": "insforge/agent-skills",
+      "sourceType": "github",
+      "computedHash": "421b6eb1091930a437c223aae1d6547f3ee4d2e5cfef45e41a3e2b32a2c27f7e"
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { HelmetProvider } from 'react-helmet-async'
+import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/react'
 import './styles/globals.css'
 import App from './App.tsx'
 
@@ -30,6 +32,8 @@ async function bootstrap() {
           </BrowserRouter>
         </QueryClientProvider>
       </HelmetProvider>
+      <Analytics />
+      <SpeedInsights />
     </StrictMode>,
   )
 }


### PR DESCRIPTION
## Summary

- Añade `/test` al ciclo de vida agéntico (entre `/review` y `/done`)
- Lanza un subagente que abre Chromium y navega la app simulando un usuario real
- Soporta modo local (mock) y `--pre` (InsForge real, pide credenciales al usuario)
- Acepta descripción libre como argumento: `/test login y reserva de cita`
- Configura `@playwright/mcp` en `~/.claude/settings.json` (headed por defecto)
- Añade permisos `curl`, `kill`, `lsof` en `.claude/settings.json`

## Nuevo ciclo de vida

```
/implement → /change (ajustes) → /review → /test → /done
```

## Test plan

- [ ] Ejecutar `/test` en una feature activa y verificar que genera `TEST.md`
- [ ] Probar `/test <descripción libre>` y verificar que el subagente sigue el texto
- [ ] Probar `/test --pre` y verificar que pide credenciales antes de abrir el browser
- [ ] Verificar que `@playwright/mcp` aparece en `~/.claude/settings.json`

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)