### PR TITLE
docs(agentic): revisar flujo /change con /plan condicional, /review y /test (#28)

### DIFF
--- a/.claude/commands/change.md
+++ b/.claude/commands/change.md
@@ -16,6 +16,22 @@ Ejemplos:
 - `/change el hook useAppointments debería recibir el userId como parámetro, no leerlo del store`
 - `/change cambia el color del botón de reserva a dorado (#C8A44E) en lugar de azul`
 
+## Flujo completo del change (referencia)
+
+```
+/change <qué>         → análisis + CHANGE-N.md (para aquí)
+[si es complejo]      → /plan actualiza PLAN.md antes de /implement
+[tú apruebas]
+/implement            → ejecuta los pasos del change
+/review               → audita el resultado
+/test                 → verifica visualmente
+(continuar con la tarea o /done si era el último paso)
+```
+
+**Regla de complejidad** — cuándo usar `/plan`:
+- Change con **≤1 paso y ≤2 archivos** → `CHANGE-N.md` es suficiente. Ir directo a `/implement`.
+- Change con **>1 paso o >2 archivos** → ejecutar `/plan` para formalizar el plan en `PLAN.md` antes de `/implement`.
+
 ## Lo que debes hacer
 
 ### 1. Registrar el change-request
@@ -83,12 +99,14 @@ Change-<N> analizado:
 
 Diagnóstico: <...>
 Archivos a tocar: <N>
+Complejidad: rápido (1 paso, ≤2 archivos) | complejo (>1 paso o >2 archivos)
 
 Plan del cambio:
   Paso C-1 — <título>
   Paso C-2 — <título>
 
-¿Apruebas? (usa /implement para ejecutarlo)
+[Si complejo]: Ejecuta /plan para formalizar este plan en PLAN.md antes de /implement.
+[Si rápido]:   ¿Apruebas? (usa /implement para ejecutarlo)
 ```
 
 ### 5. PARAR aquí
@@ -107,3 +125,10 @@ CHANGE-N implementado: <título>. Commits: <hashes>
 ```
 
 Si el CHANGE altera el PLAN original, regenerar `PLAN.md` y `PROGRESS.md` con `/revise`.
+
+A continuación, ejecutar siempre:
+
+1. **`/review`** — audita el resultado contra el Constitution y los criterios de aceptación.
+2. **`/test`** — verifica visualmente que los flujos afectados siguen funcionando.
+
+Solo si ambos pasan → continuar con la tarea o ejecutar `/done`.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -6,7 +6,8 @@ Genera `TEST.md` con veredicto PASS/FAIL por flujo.
 **Posición en el ciclo de vida**: después de `/review`, antes de `/done`.
 
 ```
-/implement → /change (ajustes) → /review → /test → /done
+/implement → /review → /test → /done
+/change (ajustes) → [/plan si complejo] → /implement → /review → /test
 ```
 
 ## Uso

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,9 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
 /plan            → PLAN.md (para, espera aprobación)
 [usuario: "ok" o /revise]
 /implement       → código paso a paso (un commit por paso)
-/change <qué>    → corrección sin saltar a código (para, espera /implement)
+/change <qué>    → análisis + CHANGE-N.md (para)
+                   [si complejo: /plan actualiza PLAN.md antes de /implement]
+                   /implement → /review → /test
 /review          → subagente audita + quality gates
 /test            → subagente abre browser y testea flujos de la app (E2E visual)
 /done            → propone PR (confirmación antes de push)
@@ -139,7 +141,7 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
 | `/revise <qué>`                   | Plan           | Ajusta el plan antes de implementar                  |
 | `/implement [N\|next\|all\|N..M]` | Implementación | **Única puerta al código de producción**             |
 | `/next`                           | Implementación | Atajo para `/implement next`                         |
-| `/change <qué>`                   | Corrección     | Analiza ajuste → propone plan → espera `/implement`  |
+| `/change <qué>`                   | Corrección     | Analiza → CHANGE-N.md → [/plan si complejo] → `/implement` → `/review` → `/test` |
 | `/review`                         | Review         | Subagente + quality gates + criterios                |
 | `/test [--pre]`                   | Test visual    | Subagente abre Chromium y recorre flujos de la app   |
 | `/done`                           | Cierre         | Propone PR (confirmación antes de push)              |


### PR DESCRIPTION
## Summary

- El comando `/change` ahora documenta el ciclo completo incluyendo `/plan` (condicional por complejidad), `/review` y `/test`
- Regla de complejidad: si el change tiene ≤1 paso y ≤2 archivos, `CHANGE-N.md` es suficiente; si es más complejo, `/plan` es obligatorio antes de `/implement`
- `CLAUDE.md` y `test.md` actualizados para coherencia con el nuevo flujo

## Test plan

- [ ] El bloque de flujo en `change.md` refleja el ciclo completo
- [ ] La regla de complejidad es clara y tiene criterio numérico
- [ ] `CLAUDE.md` no tiene contradicciones con el nuevo flujo

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)