### PR TITLE
docs(agentic): sync documentation with /test and /change flows (issue #27)

### DIFF
--- a/.claude/commands/change.md
+++ b/.claude/commands/change.md
@@ -16,6 +16,22 @@ Ejemplos:
 - `/change el hook useAppointments debería recibir el userId como parámetro, no leerlo del store`
 - `/change cambia el color del botón de reserva a dorado (#C8A44E) en lugar de azul`
 
+## Flujo completo del change (referencia)
+
+```
+/change <qué>         → análisis + CHANGE-N.md (para aquí)
+[si es complejo]      → /plan actualiza PLAN.md antes de /implement
+[tú apruebas]
+/implement            → ejecuta los pasos del change
+/review               → audita el resultado
+/test                 → verifica visualmente
+(continuar con la tarea o /done si era el último paso)
+```
+
+**Regla de complejidad** — cuándo usar `/plan`:
+- Change con **≤1 paso y ≤2 archivos** → `CHANGE-N.md` es suficiente. Ir directo a `/implement`.
+- Change con **>1 paso o >2 archivos** → ejecutar `/plan` para formalizar el plan en `PLAN.md` antes de `/implement`.
+
 ## Lo que debes hacer
 
 ### 1. Registrar el change-request
@@ -83,12 +99,14 @@ Change-<N> analizado:
 
 Diagnóstico: <...>
 Archivos a tocar: <N>
+Complejidad: rápido (1 paso, ≤2 archivos) | complejo (>1 paso o >2 archivos)
 
 Plan del cambio:
   Paso C-1 — <título>
   Paso C-2 — <título>
 
-¿Apruebas? (usa /implement para ejecutarlo)
+[Si complejo]: Ejecuta /plan para formalizar este plan en PLAN.md antes de /implement.
+[Si rápido]:   ¿Apruebas? (usa /implement para ejecutarlo)
 ```
 
 ### 5. PARAR aquí
@@ -107,3 +125,10 @@ CHANGE-N implementado: <título>. Commits: <hashes>
 ```
 
 Si el CHANGE altera el PLAN original, regenerar `PLAN.md` y `PROGRESS.md` con `/revise`.
+
+A continuación, ejecutar siempre:
+
+1. **`/review`** — audita el resultado contra el Constitution y los criterios de aceptación.
+2. **`/test`** — verifica visualmente que los flujos afectados siguen funcionando.
+
+Solo si ambos pasan → continuar con la tarea o ejecutar `/done`.

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -6,7 +6,8 @@ Genera `TEST.md` con veredicto PASS/FAIL por flujo.
 **Posición en el ciclo de vida**: después de `/review`, antes de `/done`.
 
 ```
-/implement → /change (ajustes) → /review → /test → /done
+/implement → /review → /test → /done
+/change (ajustes) → [/plan si complejo] → /implement → /review → /test
 ```
 
 ## Uso

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,4 +130,68 @@ Available languages:
 - Serverless functions have single endpoint (no subpaths)
 - Storage: Upload files to buckets, store URLs in database
 - AI operations are OpenAI-compatible
-- **EXTRA IMPORTANT**: Use Tailwind CSS 3.4 (do not upgrade to v4). Lock these dependencies in `package.json`
+- **PROJECT OVERRIDE**: This project uses **TailwindCSS v4** (not v3.4). Do not downgrade.
+
+---
+
+## Project Context — Gio Barber Shop
+
+This is **barber-dates-web**, a web booking app for a men's barbershop. Two roles: **client** (books appointments, earns loyalty points, redeems rewards) and **admin** (manages services, schedules, blocked days, metrics).
+
+**Stack**: React 19 + Vite + TypeScript strict · TailwindCSS v4 · shadcn/ui · React Router v7 · TanStack Query v5 · Zustand · Vitest + MSW v2 · InsForge (PostgreSQL + Auth + Storage)
+
+### Architecture — Clean Architecture (strict layers)
+
+```
+src/domain/           # Pure types + business rules — zero external imports
+src/infrastructure/   # InsForge adapters — imports only from domain/
+src/hooks/            # TanStack Query + orchestration — imports domain/ + infrastructure/
+src/components/       # Reusable UI — imports hooks/ + domain/
+src/pages/            # Screens — imports hooks/ + components/ + domain/
+src/stores/           # Zustand — UI state only (never remote data)
+src/lib/              # Shared utilities (cn, formatters)
+src/mocks/            # MSW handlers + fixtures (dev + tests)
+```
+
+**Import law**: `pages → components → hooks → infrastructure → domain`. Never backwards.
+**domain/ never imports**: React, InsForge SDK, date-fns, or any external package.
+**Naming**: snake_case in DB ↔ camelCase in domain. Mappers live in `infrastructure/`, never leak snake_case to upper layers.
+
+### Database Schema (PostgreSQL / InsForge)
+
+```sql
+profiles              id, full_name, phone, avatar_url, role('client'|'admin'), created_at, updated_at
+services              id, name, description, duration_minutes, price, loyalty_points, is_active, sort_order
+appointments          id, client_id→profiles, service_id→services, start_time, end_time, status, notes
+                      status: 'confirmed' | 'completed' | 'cancelled' | 'no_show'
+schedule_blocks       id, block_date, start_time, end_time, day_of_week, reason, is_recurring
+shop_config           id, key (unique), value (JSONB)
+loyalty_cards         id, client_id→profiles (unique), total_points, total_visits
+loyalty_transactions  id, card_id→loyalty_cards, appointment_id→appointments, points, type, description
+                      type: 'earned' | 'redeemed' | 'bonus' | 'adjustment'
+rewards               id, name, description, points_cost, is_active
+redeemed_rewards      id, card_id→loyalty_cards, reward_id→rewards, redeemed_at
+```
+
+### Row Level Security (RLS) — enabled on all tables
+
+| Table | Client can | Admin can |
+|-------|-----------|-----------|
+| `profiles` | Read/update own row | Read/update all |
+| `appointments` | Read/create/update own rows | Full CRUD |
+| `services` | Read (public) | Full CRUD |
+| `rewards` | Read (public) | Full CRUD |
+| `loyalty_cards` | Read own | Read all |
+| `loyalty_transactions` | Read own | Read all |
+| `schedule_blocks` | Read | Full CRUD |
+| `shop_config` | Read | Full CRUD |
+
+### Business Rules (live in `src/domain/`, never in components)
+
+1. A client can have at most **1 future active appointment** (`status='confirmed'`) at a time.
+2. Appointments can be cancelled up to **2 hours before** start time (`CANCELLATION_LIMIT_HOURS = 2`).
+3. Loyalty points are awarded when the appointment status changes to **`completed`** (not on booking or confirmation).
+4. Admin can block specific days/hours via `schedule_blocks`.
+5. Services have fixed duration that determines available booking slots.
+6. **Client session**: persistent indefinitely.
+7. **Admin session**: maximum **15 days** from login (`ADMIN_SESSION_MAX_DAYS = 15`). Force logout if exceeded. Login timestamp stored in `localStorage` under key `admin_login_time`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,7 @@ redeemed_rewards      id, card_id→loyalty_cards, reward_id→rewards, redeemed
 | `rewards` | Read (public) | Full CRUD |
 | `loyalty_cards` | Read own | Read all |
 | `loyalty_transactions` | Read own | Read all |
+| `redeemed_rewards` | Read own | Read all |
 | `schedule_blocks` | Read | Full CRUD |
 | `shop_config` | Read | Full CRUD |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,9 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
 /plan            → PLAN.md (para, espera aprobación)
 [usuario: "ok" o /revise]
 /implement       → código paso a paso (un commit por paso)
-/change <qué>    → corrección sin saltar a código (para, espera /implement)
+/change <qué>    → análisis + CHANGE-N.md (para)
+                   [si complejo: /plan actualiza PLAN.md antes de /implement]
+                   /implement → /review → /test
 /review          → subagente audita + quality gates
 /test            → subagente abre browser y testea flujos de la app (E2E visual)
 /done            → propone PR (confirmación antes de push)
@@ -139,7 +141,7 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
 | `/revise <qué>`                   | Plan           | Ajusta el plan antes de implementar                  |
 | `/implement [N\|next\|all\|N..M]` | Implementación | **Única puerta al código de producción**             |
 | `/next`                           | Implementación | Atajo para `/implement next`                         |
-| `/change <qué>`                   | Corrección     | Analiza ajuste → propone plan → espera `/implement`  |
+| `/change <qué>`                   | Corrección     | Analiza → CHANGE-N.md → [/plan si complejo] → `/implement` → `/review` → `/test` |
 | `/review`                         | Review         | Subagente + quality gates + criterios                |
 | `/test [--pre]`                   | Test visual    | Subagente abre Chromium y recorre flujos de la app   |
 | `/done`                           | Cierre         | Propone PR (confirmación antes de push)              |

--- a/docs/03-flujo-de-desarrollo.md
+++ b/docs/03-flujo-de-desarrollo.md
@@ -86,10 +86,14 @@ Todo desarrollo no trivial sigue este ciclo. Los comandos son los puntos de cont
           │  Claude:               │           │
           │  1. Analiza el cambio  │           │
           │  2. Crea CHANGE-N.md   │           │
-          │  3. Plan de corrección │           │
-          │  4. PARA               │           │
+          │  3. PARA               │           │
           │                        │           │
-          │  Tú: "ok" → /implement │           │
+          │  ≤1 paso / ≤2 archivos │           │
+          │  → /implement directo  │           │
+          │                        │           │
+          │  >1 paso o >2 archivos │           │
+          │  → /plan primero       │           │
+          │  → /implement          │           │
           └─────────────┬──────────┘           │
                         └──────────────────────┘
                                                │
@@ -105,6 +109,18 @@ Todo desarrollo no trivial sigue este ciclo. Los comandos son los puntos de cont
 ║    3. Verifica criterios de aceptación del README.md             ║
 ║    4. Escribe REVIEW.md con veredicto                            ║
 ║    5. Reporta: APROBADO o BLOQUEADO (con qué hay que arreglar)   ║
+╚══════════════════════════════════════════════╦═══════════════════╝
+                                               │
+╔══════════════════════════════════════════════▼═══════════════════╗
+║  TEST                                                            ║
+║                                                                  ║
+║  Tú: /test  (o /test <descripción>, /test --pre)                 ║
+║                                                                  ║
+║  Claude hace:                                                    ║
+║    1. Lanza subagente Playwright que abre Chromium               ║
+║    2. Navega los flujos principales de la tarea                  ║
+║    3. Escribe TEST.md con veredicto PASS / FAIL por flujo        ║
+║    4. Si hay FAILs: reporta y para. Vuelves a /change o /review  ║
 ╚══════════════════════════════════════════════╦═══════════════════╝
                                                │
 ╔══════════════════════════════════════════════▼═══════════════════╗
@@ -134,6 +150,7 @@ Todo desarrollo no trivial sigue este ciclo. Los comandos son los puntos de cont
 | `/plan`                 | Sin contrato escrito, imposible retomar si se interrumpe. Claude improvisa     |
 | `/implement`            | No existe — es la puerta obligatoria al código. Sin ella no hay código         |
 | `/review`               | Los errores de capas (components importando de infrastructure) son silenciosos |
+| `/test`                 | Un bug visual que pasa type-check y lint llega a producción sin que nadie lo vea |
 | Context sync en `/done` | Constitution desactualizado → siguiente tarea trabaja con info falsa           |
 
 ---
@@ -162,6 +179,7 @@ A veces mientras haces una feature descubres que necesitas hacer algo más peque
 /plan    # plan quirúrgico, máximo 3 pasos
 /implement
 /review
+/test
 /done
 # Claude te recuerda SIEMPRE: "hay que hacer cherry-pick a develop"
 ```

--- a/docs/04-referencia-comandos.md
+++ b/docs/04-referencia-comandos.md
@@ -224,8 +224,10 @@ Lanza un subagente que abre Chromium, navega la app y verifica que los flujos pr
 | `/test --pre <desc>`  | Lo que describes contra InsForge PRE               |
 
 **Precondiciones**:
+- El plan está en estado `approved` o `done` (todos los pasos implementados).
 - `/review` ejecutado sin bloqueos abiertos.
 - MCP de Playwright configurado en `~/.claude/settings.json` (ver [05-sistema-de-tareas.md](05-sistema-de-tareas.md)).
+- Para `/test --pre`: credenciales de acceso a InsForge PRE disponibles (se piden al ejecutar).
 
 **Genera**: `TEST.md` con veredicto PASS / FAIL por flujo.
 

--- a/docs/04-referencia-comandos.md
+++ b/docs/04-referencia-comandos.md
@@ -10,7 +10,7 @@
 | Categoría       | Comandos                                                                      |
 | --------------- | ----------------------------------------------------------------------------- |
 | **Arranque**    | `/feature` `/fix` `/refactor` `/chore` `/hotfix` `/spike`                     |
-| **Ciclo**       | `/analyze` `/plan` `/revise` `/implement` `/next` `/change` `/review` `/done` |
+| **Ciclo**       | `/analyze` `/plan` `/revise` `/implement` `/next` `/change` `/review` `/test` `/done` |
 | **Sesión**      | `/status` `/resume` `/pause` `/block` `/handoff` `/compact-task`              |
 | **Contexto**    | `/sync-context` `/learn` `/ask` `/worktree`                                   |
 | **Scaffolding** | `/new-domain` `/new-infra` `/new-hook` `/new-component` `/new-page`           |
@@ -176,9 +176,18 @@ Flujo de corrección controlada. Cuando algo no quedó como querías.
 **Lo que SÍ hace**:
 
 1. Analiza qué implica el cambio sin tocar nada.
-2. Crea `CHANGES/CHANGE-N.md` con diagnóstico y plan.
-3. Te lo muestra y para.
+2. Crea `CHANGES/CHANGE-N.md` con diagnóstico y plan propuesto.
+3. Te lo muestra y **para**.
 4. Espera a que tú ejecutes `/implement`.
+
+**Ciclo completo**:
+
+```
+/change <qué>
+  └─ si ≤ 1 paso y ≤ 2 archivos → /implement directamente
+  └─ si > 1 paso o > 2 archivos → /plan (formaliza PLAN.md) → /implement
+/implement → /review → /test → continuar o /done
+```
 
 ```
 /change el hook useAppointments debería recibir userId como parámetro, no leerlo del store
@@ -199,6 +208,32 @@ Audita el resultado implementado antes de cerrar:
 
 ```
 /review
+```
+
+---
+
+### `/test`
+
+Lanza un subagente que abre Chromium, navega la app y verifica que los flujos principales funcionan visualmente. **Posición en el ciclo**: después de `/review`, antes de `/done`.
+
+| Variante              | Qué hace                                           |
+| --------------------- | -------------------------------------------------- |
+| `/test`               | Flujos por defecto contra servidor local (mocks)   |
+| `/test <descripción>` | Testea exactamente lo que describes (local)        |
+| `/test --pre`         | Flujos por defecto contra InsForge PRE (real)      |
+| `/test --pre <desc>`  | Lo que describes contra InsForge PRE               |
+
+**Precondiciones**:
+- `/review` ejecutado sin bloqueos abiertos.
+- MCP de Playwright configurado en `~/.claude/settings.json` (ver [05-sistema-de-tareas.md](05-sistema-de-tareas.md)).
+
+**Genera**: `TEST.md` con veredicto PASS / FAIL por flujo.
+
+```
+/test
+/test login y registro
+/test que se puede reservar una cita y cancelarla
+/test --pre el flujo completo de puntos de fidelidad
 ```
 
 ---

--- a/docs/06-buenas-practicas.md
+++ b/docs/06-buenas-practicas.md
@@ -128,10 +128,16 @@ Claude:
 
 Tú: "ok" (o "cambia el paso 1...")
 
+# Regla de complejidad:
+# ≤ 1 paso y ≤ 2 archivos → /implement directamente
+# > 1 paso o > 2 archivos → /plan primero (formaliza en PLAN.md), luego /implement
+
 Tú: /implement
   → Claude ejecuta los pasos del CHANGE
   → Commit(s) con mensaje descriptivo
   → CHANGE marcado como "done"
+
+Tú: /review → /test   # siempre después de implementar un change
 ```
 
 ### Lo que garantiza
@@ -208,6 +214,10 @@ Tú: /implement
 # Tests: ✅ 31 passed
 # Criterios: 5/5 ✅
 
+/test
+# Subagente Playwright: abre Chromium, navega los flujos de loyalty
+# ✅ PASS — badge aparece en header, puntos se acumulan al completar cita
+
 /done
 # Context sync: "Art. 4 desactualizado — propongo añadir regla 8 sobre puntos de fidelización"
 # Tú: "sí"
@@ -236,6 +246,9 @@ Tú: /implement
 # Fix → commit fix(calendar): handle viewport-dependent slot calculation
 
 /review  # todo pasa
+
+/test
+# ✅ PASS — la reserva de cita en móvil funciona correctamente
 
 /done
 # Claude: "¿Procedo con PR a main? RECORDATORIO: hacer cherry-pick del fix a develop"


### PR DESCRIPTION
## Summary

- Add `/test` to command reference index and dedicated `### /test` section in `docs/04`
- Add TEST block to cycle diagram in `docs/03` and update `/change` block with complexity rule (≤1 step/≤2 files → direct; otherwise `/plan` first)
- Add `/test` step to workflow examples A and B in `docs/06`
- Add project context to `AGENTS.md`: architecture layers, DB schema (9 tables), RLS rules per table, 7 business rules — no credentials or backend URLs
- Fix incorrect Tailwind version note in `AGENTS.md` (was v3.4, project uses v4)

## Test plan

- [ ] `docs/04-referencia-comandos.md` tiene `/test` en la fila Ciclo del índice y sección `### /test` dedicada
- [ ] `docs/03-flujo-de-desarrollo.md` muestra bloque TEST entre REVIEW y CIERRE en el diagrama
- [ ] `docs/06-buenas-practicas.md` muestra `/review → /test → /done` en los ejemplos A y B
- [ ] `AGENTS.md` contiene sección `## Project Context` con schema (9 tablas), reglas y capas, sin credenciales

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)