### PR TITLE
feat(agentic): InsForge PRO MCP + comando /optimize

### DIFF
--- a/.claude/CONSTITUTION.md
+++ b/.claude/CONSTITUTION.md
@@ -242,7 +242,9 @@ Formato: `type(scope): descripción en inglés, presente imperativo`.
 
 ---
 
-## Art. 13 — Variables de entorno
+## Art. 13 — Variables de entorno y MCP servers
+
+### Variables de entorno (frontend)
 
 ```bash
 VITE_INSFORGE_URL=
@@ -257,6 +259,30 @@ VITE_MOCK_ROLE=client         # rol del usuario fake al hacer login: "client" | 
 ```
 
 Nunca commitear `.env*` excepto `.env.example`.
+
+### MCP servers de InsForge (Claude Code)
+
+Configurados globalmente en `~/.claude/settings.json` (fuera del repo, nunca commiteado).  
+Para añadir un nuevo proyecto InsForge, añadir una entrada bajo `mcpServers`:
+
+```json
+"insforge-<nombre>": {
+  "command": "npx",
+  "args": [
+    "@insforge/mcp",
+    "--api_key", "ik_TU_KEY",
+    "--api_base_url", "https://TU_URL.eu-central.insforge.app"
+  ]
+}
+```
+
+| Nombre MCP | Entorno | URL |
+|---|---|---|
+| `insforge-pre` | PRE (desarrollo) | `https://99upfj9c.eu-central.insforge.app` |
+| `insforge-prod` | PRO (producción) | `https://pfzm89u2.eu-central.insforge.app` |
+
+Las API keys se obtienen desde InsForge Dashboard → Connect Project → API Keys.  
+Los cambios en `~/.claude/settings.json` requieren reiniciar Claude Code para tomar efecto.
 
 ---
 

--- a/.claude/KNOWLEDGE.md
+++ b/.claude/KNOWLEDGE.md
@@ -8,7 +8,17 @@ Cada entrada debe tener: **Fecha · Contexto · Qué · Por qué importa**.
 
 ## Entorno y arranque
 
-_(vacío — se irá llenando)_
+### 2026-04-19 · InsForge MCP · cómo conectarse a PRE vs PRO desde Claude Code
+
+**Qué**: hay dos MCP servers globales configurados en `~/.claude/settings.json`: `insforge-pre` (desarrollo) e `insforge-prod` (producción). Claude Code los carga al arrancar la sesión.
+
+**Cómo usarlos**: al iniciar una sesión de Claude Code, ambos MCP servers están disponibles automáticamente. Para operar sobre PRE (lo normal durante desarrollo), usar las herramientas con prefijo `insforge-pre`. Para inspeccionar PRO, usar `insforge-prod` — con cuidado, son datos reales.
+
+**Credenciales y URLs**: ver Art. 13 del Constitution. Las API keys están solo en `~/.claude/settings.json` (fuera del repo).
+
+**Si las herramientas no aparecen**: los MCPs se cargan solo al inicio de sesión. Si se modificó `~/.claude/settings.json` durante la sesión, hay que reiniciar Claude Code para que tome efecto.
+
+**Para añadir un nuevo proyecto InsForge**: editar `~/.claude/settings.json` directamente — ver Art. 13 para el formato exacto.
 
 ## Gotchas del stack
 

--- a/.claude/commands/optimize.md
+++ b/.claude/commands/optimize.md
@@ -1,0 +1,101 @@
+# Comando: /optimize
+
+Arranca un flujo completo de optimización: crea rama + carpeta + análisis especializado por scope.
+Se para al terminar el análisis — **no implementa nada hasta que el usuario apruebe el plan**.
+
+## Uso
+
+```
+/optimize [scope]
+```
+
+Sin scope → analiza todo (bundle + queries + accessibility + seo + renders).  
+Con scope → foco en esa área concreta.
+
+**Scopes disponibles**:
+
+| Scope | Qué analiza | Herramientas |
+|---|---|---|
+| `bundle` | Tamaño de chunks, tree-shaking, imports dinámicos | `pnpm run analyze`, revisión de `import()` lazy |
+| `queries` | N+1, paginación, campos innecesarios, índices | Revisión de `infrastructure/` adapters InsForge |
+| `accessibility` | aria labels, keyboard nav, focus management, contraste | Revisión estática de componentes |
+| `seo` | SeoHead por página, robots.txt, llms.txt, prerenderizado | Revisión de `pages/` y `public/` |
+| `renders` | Re-renders innecesarios, memo, useMemo, useCallback | Revisión de hooks y componentes |
+| *(sin args)* | Todos los anteriores | Suma de todas las herramientas |
+
+## Flujo completo de una optimización
+
+```
+/optimize [scope]  → crea rama + carpeta + ANÁLISIS especializado (para aquí)
+[tú revisas los hallazgos y prioridades]
+/plan              → PLAN.md con optimizaciones priorizadas (para aquí)
+[tú apruebas o pides /revise]
+/implement         → ejecuta las optimizaciones paso a paso
+/review            → audita que no hay regresiones
+/test              → verifica en browser que todo funciona
+/done              → propone PR (con confirmación)
+[Si algo falla: /change <qué> → nuevo ciclo implement → review → test]
+```
+
+## Lo que debes hacer al ejecutar /optimize
+
+### 1. Determinar el scope
+
+- Si el usuario no especificó scope → scope = `all` (analiza todo).
+- Si especificó uno o varios → foco en esos.
+
+### 2. Crear la rama y carpeta de tarea
+
+```bash
+git checkout develop && git pull origin develop
+git checkout -b refactor/optimize-<scope>
+bash .claude/scripts/new-task.sh refactor "optimize-<scope>" "Optimización: <scope>"
+```
+
+Si scope = all → slug `optimize-all`, descripción `"Optimización general: bundle, queries, a11y, seo, renders"`.
+
+### 3. Ejecutar el análisis especializado por scope
+
+Lee `.claude/workflows/optimize.md` y aplica la sección correspondiente al scope pedido.
+
+El análisis debe:
+- Usar las herramientas descritas en el workflow para cada scope.
+- Identificar problemas concretos con archivo + línea siempre que sea posible.
+- Estimar impacto (alto / medio / bajo) y esfuerzo (pequeño / medio / grande).
+
+### 4. Generar el reporte priorizado
+
+Formato del reporte:
+
+```
+## Hallazgos de optimización — <scope> (<fecha>)
+
+### 🔴 Crítico (impacto alto / esfuerzo bajo — hacer primero)
+- [BUN-01] chunk `vendor` (1.2 MB sin gzip) — separar react-pdf con import() dinámico → estimado -400 KB
+- [QRY-01] `getAppointments` carga todos los registros sin paginar — añadir `.range()` InsForge
+
+### 🟡 Mejora (impacto medio o esfuerzo medio)
+- [RND-01] `<CalendarGrid>` re-renderiza en cada keystroke del buscador — memo o debounce
+- [SEO-01] Página `/barber/:id` no tiene meta description dinámica
+
+### 🟢 Nice-to-have (bajo impacto o alto esfuerzo)
+- [A11Y-01] Botón de cancelar cita sin aria-label explícito
+
+## Recomendación
+[Breve párrafo: qué atacar primero y por qué]
+```
+
+Guardar el reporte en `ANALYSIS.md` de la tarea.
+
+### 5. PARAR
+
+Presentar el reporte al usuario. Indicarle que si aprueba los hallazgos, ejecute `/plan` para priorizar y planificar las implementaciones.
+
+**No implementar nada todavía. No tocar `src/`.**
+
+## Notas
+
+- El código de cada hallazgo usa prefijo de scope: `BUN`, `QRY`, `A11Y`, `SEO`, `RND`.
+- La rama es `refactor/` porque el objetivo es mejorar sin cambiar comportamiento observable.
+  Excepción: si una optimización añade funcionalidad (ej. paginación), la rama puede ser `feature/`.
+- En el `/plan` subsiguiente, cada hallazgo 🔴 debe ser un paso del plan; los 🟡 se agrupan o priorizan según el usuario.

--- a/.claude/workflows/optimize.md
+++ b/.claude/workflows/optimize.md
@@ -1,0 +1,126 @@
+# Workflow: /optimize — guía de análisis por scope
+
+> Esta guía es la referencia interna del comando `/optimize`.
+> Claude la lee durante la fase de análisis para saber qué revisar en cada scope.
+
+---
+
+## Scope: `bundle`
+
+**Objetivo**: identificar oportunidades de reducir el tamaño del bundle JS/CSS entregado al navegador.
+
+**Herramientas**:
+```bash
+pnpm run analyze   # abre Vite bundle visualizer en el browser
+```
+
+**Qué buscar**:
+1. Chunks principales > 200 KB sin gzip → candidatos a splitting con `import()`.
+2. Dependencias pesadas incluidas en el chunk `vendor` que solo se usan en una ruta → moverlas a import dinámico.
+3. `import` estáticos en `pages/` de librerías que podrían ser dinámicos (`react-pdf`, `chart.js`, etc.).
+4. Duplicados de paquetes en el bundle (dos versiones de la misma lib).
+5. Assets de imágenes sin optimizar incluidos en el bundle.
+
+**Cómo reportarlo**: `[BUN-N] <descripción> → <acción concreta> → estimado <X KB ahorro>`
+
+---
+
+## Scope: `queries`
+
+**Objetivo**: identificar ineficiencias en las llamadas a InsForge (Supabase).
+
+**Dónde mirar**: `src/infrastructure/` — todos los archivos `*.adapter.ts` o `*.repository.ts`.
+
+**Qué buscar**:
+1. **Sin paginación**: llamadas que traen todos los registros (`.select()` sin `.range()` o `.limit()`).
+2. **N+1**: bucle que hace una llamada por iteración en lugar de un join o `.in()`.
+3. **Campos innecesarios**: `.select('*')` cuando solo se usan 2-3 columnas.
+4. **Sin índices obvios**: filtros por columnas que probablemente no tienen índice (fecha, foreign key, status).
+5. **Llamadas duplicadas**: dos adapters distintos que hacen la misma query.
+
+**Herramientas**:
+- Usar `insforge-pre` MCP (herramienta `execute_sql`) para `EXPLAIN ANALYZE` de queries sospechosas.
+- Grep en `src/infrastructure/` para `.select(` y `.eq(` para encontrar todos los puntos de acceso.
+
+**Cómo reportarlo**: `[QRY-N] <adapter>:<línea> — <problema> → <solución>` 
+
+---
+
+## Scope: `accessibility`
+
+**Objetivo**: identificar barreras de accesibilidad en los componentes UI.
+
+**Dónde mirar**: `src/components/` y `src/pages/`.
+
+**Qué buscar**:
+1. **Botones sin etiqueta**: `<button>` con solo un icono y sin `aria-label`.
+2. **Imágenes sin alt**: `<img>` sin `alt` o con `alt=""` incorrectos.
+3. **Foco no gestionado**: modales/dialogs que no atrapan el foco ni lo devuelven al cerrar.
+4. **Contraste de color**: elementos de texto con ratio < 4.5:1 (revisar en Tailwind config y paleta Art. 10).
+5. **Navegación por teclado**: componentes interactivos no accesibles con Tab/Enter/Escape.
+6. **Landmarks**: ausencia de `<main>`, `<nav>`, `<header>` semánticos.
+7. **Form labels**: inputs sin `<label>` asociado o sin `aria-label`.
+
+**Cómo reportarlo**: `[A11Y-N] <componente>:<línea> — <problema> → <solución>`
+
+---
+
+## Scope: `seo`
+
+**Objetivo**: verificar que las páginas son indexables correctamente y bien descritas para buscadores.
+
+**Dónde mirar**: `src/pages/`, `public/robots.txt`, `public/llms.txt`, uso de `<SeoHead>`.
+
+**Qué buscar**:
+1. **Páginas sin SeoHead**: rutas públicas (landing, barber profile, etc.) sin meta title/description.
+2. **Títulos genéricos**: SeoHead con `title="Gio Barber Shop"` igual en todas las páginas.
+3. **robots.txt**: rutas de admin/dashboard bloqueadas correctamente con `Disallow`.
+4. **llms.txt**: existe y describe el propósito del sitio para LLMs.
+5. **Prerenderizado**: páginas con contenido estático que podrían prebuildarse (Art. 12).
+6. **Open Graph**: ausencia de `og:image`, `og:title`, `og:description` en páginas compartibles.
+7. **Canonical URL**: duplicados de ruta sin canonical.
+
+**Cómo reportarlo**: `[SEO-N] <página/archivo> — <problema> → <solución>`
+
+---
+
+## Scope: `renders`
+
+**Objetivo**: identificar re-renders innecesarios que degradan la experiencia de usuario.
+
+**Dónde mirar**: `src/components/`, `src/hooks/`, `src/pages/`.
+
+**Qué buscar**:
+1. **Objetos/arrays inline en JSX**: `<Comp style={{ ... }}>` — nuevo objeto en cada render.
+2. **Funciones inline en JSX**: `<Comp onClick={() => fn(id)}>` sin `useCallback`.
+3. **Contextos de valor amplio**: un Context que incluye datos que cambian frecuentemente y tiene muchos consumidores.
+4. **Componentes de lista sin memo**: items de lista que re-renderizan aunque su prop no cambie.
+5. **useMemo/useCallback mal usado**: dependencias que siempre cambian, haciendo el memo inútil.
+6. **Selectors de TanStack Query demasiado amplios**: query que devuelve un objeto grande cuando solo se necesita un campo.
+
+**Herramientas**:
+- Revisión estática de código (no requiere profiler).
+- En `/test` posterior: verificar con React DevTools Profiler si aplica.
+
+**Cómo reportarlo**: `[RND-N] <componente>:<línea> — <problema> → <solución>`
+
+---
+
+## Scope: `all` (sin argumentos)
+
+Ejecutar los 5 scopes anteriores en secuencia. El reporte agrupa todos los hallazgos con sus prefijos.
+
+**Orden recomendado**: `bundle` → `queries` → `renders` → `seo` → `accessibility`  
+(de mayor a menor impacto típico en apps SPA con backend InsForge)
+
+---
+
+## Priorización para el reporte final
+
+| Severidad | Criterio |
+|---|---|
+| 🔴 Crítico | Impacto alto (> 20% mejora) Y esfuerzo bajo (< 2h) |
+| 🟡 Mejora | Impacto medio O esfuerzo medio (2-8h) |
+| 🟢 Nice-to-have | Impacto bajo O esfuerzo alto (> 8h) |
+
+Cada hallazgo debe tener: código (`BUN-01`), descripción, archivo:línea si aplica, y acción concreta.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,9 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
 [usuario aprueba items → /change por cada uno]
 ```
 
+> **`/optimize`** sigue este mismo ciclo pero arranca con análisis especializado de rendimiento/calidad.
+> Ver sección de comandos y `.claude/commands/optimize.md`.
+
 ---
 
 ## Comandos disponibles
@@ -139,6 +142,7 @@ bash .claude/scripts/files-touched.sh       # archivos tocados en la tarea
 | `/chore <slug>`                   | Arranque       | Mantenimiento (deps, config, scripts)                |
 | `/hotfix <slug>`                  | Arranque       | Urgente a prod (base: `main`)                        |
 | `/spike <slug>`                   | Arranque       | Exploración time-boxed                               |
+| `/optimize [scope]`               | Arranque       | Flujo completo de optimización (análisis → plan → implement → review → test). Sin scope = todo; scopes: `bundle`, `queries`, `accessibility`, `seo`, `renders` |
 | `/analyze`                        | Análisis       | Re-ejecuta análisis con nueva info                   |
 | `/plan`                           | Plan           | Genera PLAN.md con pasos                             |
 | `/revise <qué>`                   | Plan           | Ajusta el plan antes de implementar                  |


### PR DESCRIPTION
## Summary
- Documenta los MCP servers `insforge-pre` e `insforge-prod` en Art. 13 del Constitution y `KNOWLEDGE.md` — incluyendo cómo añadir proyectos nuevos desde InsForge Dashboard
- Añade `/optimize [scope]` como comando completo estilo `/feature`: análisis → plan → implement → review → test → done
- Scopes soportados: `bundle`, `queries`, `accessibility`, `seo`, `renders` (sin args = todos)
- Reporte priorizado con códigos `BUN`/`QRY`/`A11Y`/`SEO`/`RND` y severidad 🔴/🟡/🟢

Closes #24, closes #25

## Test plan
- [ ] Reiniciar Claude Code y verificar que `insforge-pre` e `insforge-prod` aparecen como MCP servers disponibles
- [ ] Invocar `/optimize bundle` en una sesión futura y confirmar que sigue el flujo documentado (análisis → reporte → /plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)