### PR TITLE
fix(admin): calendar grid alignment + appointment reschedule

### DIFF
--- a/src/components/admin/RescheduleModal.tsx
+++ b/src/components/admin/RescheduleModal.tsx
@@ -1,0 +1,205 @@
+import { useState } from 'react'
+import { Modal } from '@/components/ui'
+import { MonthCalendar, TimeSlots } from '@/components/calendar'
+import { MOCK_SERVICES, MOCK_BARBERS, MOCK_TAKEN_SLOTS } from '@/lib/mock-data'
+import type { WeekAppt, RescheduleUpdate } from './types'
+
+interface Props {
+  appt: WeekAppt
+  weekStart: Date
+  onClose: () => void
+  onConfirm: (update: RescheduleUpdate) => void
+}
+
+const LABEL: React.CSSProperties = {
+  fontFamily: 'var(--font-display)',
+  fontSize: 11,
+  letterSpacing: '0.12em',
+  color: 'var(--fg-3)',
+  marginBottom: '0.5rem',
+}
+
+export function RescheduleModal({ appt, weekStart, onClose, onConfirm }: Props) {
+  const initialDate = new Date(weekStart)
+  initialDate.setDate(initialDate.getDate() + appt.day)
+
+  const initialSlot = `${appt.startH.toString().padStart(2, '0')}:${appt.startM.toString().padStart(2, '0')}`
+  const initialServiceId = MOCK_SERVICES.find(s => s.name === appt.service)?.id ?? MOCK_SERVICES[0].id
+
+  const [serviceId, setServiceId] = useState(initialServiceId)
+  const [barberId, setBarberId] = useState(appt.barberId)
+  const [date, setDate] = useState<Date | null>(initialDate)
+  const [slot, setSlot] = useState<string | null>(initialSlot)
+  const [month, setMonth] = useState(initialDate.getMonth())
+  const [year, setYear] = useState(initialDate.getFullYear())
+
+  const selectedService = MOCK_SERVICES.find(s => s.id === serviceId)
+  const selectedBarber = MOCK_BARBERS.find(b => b.id === barberId)
+  const canConfirm = !!(serviceId && barberId && date && slot)
+
+  const handleConfirm = () => {
+    if (!date || !slot) return
+    onConfirm({ serviceId, barberId, date, slot })
+  }
+
+  return (
+    <Modal title="Reprogramar cita" onClose={onClose}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+
+        {/* Cita actual — solo lectura */}
+        <div style={{
+          padding: '0.75rem 1rem',
+          borderRadius: 8,
+          background: 'var(--bg-3)',
+          border: '1px solid var(--line)',
+          fontFamily: 'var(--font-ui)',
+          fontSize: 13,
+          color: 'var(--fg-2)',
+        }}>
+          <span style={{ fontWeight: 600, color: 'var(--fg-0)' }}>{appt.client}</span>
+          {' · '}{initialSlot}{' · '}{appt.service}
+        </div>
+
+        {/* Servicio */}
+        <div>
+          <div style={LABEL}>SERVICIO</div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.375rem' }}>
+            {MOCK_SERVICES.filter(s => s.active).map(s => (
+              <button
+                key={s.id}
+                onClick={() => setServiceId(s.id)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '0.6rem 0.875rem',
+                  minHeight: 44,
+                  borderRadius: 8,
+                  border: serviceId === s.id ? '1px solid var(--led-soft)' : '1px solid var(--line)',
+                  background: serviceId === s.id ? 'rgba(123,79,255,0.1)' : 'var(--bg-3)',
+                  color: 'var(--fg-0)',
+                  cursor: 'pointer',
+                  textAlign: 'left',
+                  transition: 'all 0.12s',
+                }}
+              >
+                <span style={{ fontFamily: 'var(--font-ui)', fontSize: 13, fontWeight: 500 }}>{s.name}</span>
+                <span style={{ fontFamily: 'var(--font-ui)', fontSize: 12, color: 'var(--fg-2)' }}>
+                  {s.duration} min · {s.price}€
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Barbero */}
+        <div>
+          <div style={LABEL}>BARBERO</div>
+          <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+            {MOCK_BARBERS.filter(b => b.active).map(b => (
+              <button
+                key={b.id}
+                onClick={() => setBarberId(b.id)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem',
+                  padding: '0.5rem 0.875rem',
+                  minHeight: 40,
+                  borderRadius: 8,
+                  border: barberId === b.id ? '1px solid var(--led-soft)' : '1px solid var(--line)',
+                  background: barberId === b.id ? 'rgba(123,79,255,0.1)' : 'var(--bg-3)',
+                  color: barberId === b.id ? 'var(--fg-0)' : 'var(--fg-1)',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  fontFamily: 'var(--font-ui)',
+                  transition: 'all 0.12s',
+                }}
+              >
+                <div style={{
+                  width: 26, height: 26, borderRadius: '50%',
+                  background: 'var(--bg-4)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 10, fontWeight: 700, color: 'var(--fg-1)',
+                }}>
+                  {b.initials}
+                </div>
+                {b.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Fecha */}
+        <div>
+          <div style={LABEL}>FECHA</div>
+          <MonthCalendar
+            selected={date}
+            onSelect={d => { setDate(d); setSlot(null) }}
+            month={month}
+            year={year}
+            onMonthChange={(m, y) => { setMonth(m); setYear(y) }}
+          />
+        </div>
+
+        {/* Hora */}
+        {date && (
+          <div>
+            <div style={LABEL}>HORA</div>
+            <TimeSlots
+              selected={slot}
+              onSelect={setSlot}
+              taken={MOCK_TAKEN_SLOTS}
+            />
+          </div>
+        )}
+
+        {/* Resumen */}
+        {canConfirm && selectedService && selectedBarber && date && slot && (
+          <div style={{
+            padding: '0.75rem 1rem',
+            borderRadius: 8,
+            background: 'rgba(123,79,255,0.07)',
+            border: '1px solid rgba(123,79,255,0.2)',
+            fontFamily: 'var(--font-ui)',
+            fontSize: 13,
+            color: 'var(--fg-1)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.25rem',
+          }}>
+            <span><strong style={{ color: 'var(--fg-0)' }}>{appt.client}</strong></span>
+            <span>
+              {selectedService.name} · {selectedBarber.name}
+              {' · '}
+              {date.toLocaleDateString('es-ES', { weekday: 'short', day: 'numeric', month: 'short' })} {slot}
+            </span>
+          </div>
+        )}
+
+        {/* Botón confirmar */}
+        <button
+          disabled={!canConfirm}
+          onClick={handleConfirm}
+          style={{
+            width: '100%',
+            padding: '0.875rem',
+            minHeight: 48,
+            borderRadius: 8,
+            border: 'none',
+            background: canConfirm ? 'var(--led)' : 'var(--bg-4)',
+            color: canConfirm ? '#fff' : 'var(--fg-3)',
+            fontFamily: 'var(--font-display)',
+            fontSize: 15,
+            letterSpacing: '0.06em',
+            cursor: canConfirm ? 'pointer' : 'default',
+            boxShadow: canConfirm ? 'var(--glow-led)' : 'none',
+            transition: 'all 0.15s',
+          }}
+        >
+          GUARDAR CAMBIOS
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/admin/index.ts
+++ b/src/components/admin/index.ts
@@ -1,3 +1,5 @@
 export { AgendaListView } from './AgendaListView'
 export type { AgendaItem } from './AgendaListView'
 export { NewAppointmentModal } from './NewAppointmentModal'
+export { RescheduleModal } from './RescheduleModal'
+export type { WeekAppt, RescheduleUpdate } from './types'

--- a/src/components/admin/types.ts
+++ b/src/components/admin/types.ts
@@ -1,0 +1,18 @@
+export interface WeekAppt {
+  id: string
+  day: number       // 0=Mon … 5=Sat
+  startH: number
+  startM: number
+  durationMin: number
+  client: string
+  service: string   // display name matching MOCK_SERVICES
+  barberId: string
+  color: 'led' | 'brick' | 'gold'
+}
+
+export interface RescheduleUpdate {
+  serviceId: string
+  barberId: string
+  date: Date
+  slot: string      // "HH:MM"
+}

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -2,14 +2,14 @@ import { useState, useEffect, useRef } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { useShopContext } from '@/context/ShopContext'
 import { Icon } from '@/components/ui'
-import { AgendaListView, NewAppointmentModal } from '@/components/admin'
-import type { WeekAppt } from '@/components/admin'
-import { MOCK_BARBERS } from '@/lib/mock-data'
+import { AgendaListView, NewAppointmentModal, RescheduleModal } from '@/components/admin'
+import type { WeekAppt, RescheduleUpdate } from '@/components/admin'
+import { MOCK_BARBERS, MOCK_SERVICES } from '@/lib/mock-data'
 
 const DAYS_ES = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
 const HOURS = Array.from({ length: 11 }, (_, i) => i + 9) // 9 → 19
 
-const WEEK_APPOINTMENTS: WeekAppt[] = [
+const INITIAL_APPOINTMENTS: WeekAppt[] = [
   { id: 'w1',  day: 0, startH: 10, startM: 0,  durationMin: 45, client: 'Carlos M.',   service: 'Corte + Barba',         barberId: 'b1', color: 'led' },
   { id: 'w2',  day: 0, startH: 11, startM: 30, durationMin: 30, client: 'Rubén G.',    service: 'Corte Clásico',          barberId: 'b2', color: 'brick' },
   { id: 'w3',  day: 0, startH: 14, startM: 0,  durationMin: 60, client: 'Javier P.',   service: 'Corte Premium',          barberId: 'b1', color: 'led' },
@@ -58,15 +58,44 @@ export default function DashboardPage() {
   const { name: shopName } = useShopContext()
   const [weekOffset, setWeekOffset] = useState(0)
   const [dayOffset, setDayOffset] = useState(0)
+  const [appointments, setAppointments] = useState<WeekAppt[]>(INITIAL_APPOINTMENTS)
   const [selectedAppt, setSelectedAppt] = useState<WeekAppt | null>(null)
+  const [rescheduleAppt, setRescheduleAppt] = useState<WeekAppt | null>(null)
   const [newApptOpen, setNewApptOpen] = useState(false)
   const [newApptToast, setNewApptToast] = useState(false)
+  const [rescheduleToast, setRescheduleToast] = useState(false)
   const nowLineRef = useRef<HTMLDivElement>(null)
 
   const handleNewApptConfirm = () => {
     setNewApptOpen(false)
     setNewApptToast(true)
     setTimeout(() => setNewApptToast(false), 3000)
+  }
+
+  const handleRescheduleConfirm = async (update: RescheduleUpdate) => {
+    if (!rescheduleAppt) return
+    const [newH, newM] = update.slot.split(':').map(Number)
+    const newDayIdx = Math.round((update.date.getTime() - weekStart.getTime()) / 86_400_000)
+    const newService = MOCK_SERVICES.find(s => s.id === update.serviceId)?.name ?? rescheduleAppt.service
+
+    setAppointments(prev => prev.map(a =>
+      a.id === rescheduleAppt.id
+        ? { ...a, day: newDayIdx, startH: newH, startM: newM, service: newService, barberId: update.barberId }
+        : a
+    ))
+
+    try {
+      await fetch(`/rest/v1/appointments?id=eq.${rescheduleAppt.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scheduled_at: update.date.toISOString() }),
+      })
+    } catch { /* mock data — ignorar */ }
+
+    setRescheduleAppt(null)
+    setSelectedAppt(null)
+    setRescheduleToast(true)
+    setTimeout(() => setRescheduleToast(false), 3000)
   }
 
   const weekStart = getWeekStart(new Date())
@@ -87,13 +116,13 @@ export default function DashboardPage() {
   mobileDayDate.setDate(mobileDayDate.getDate() + mobileDayCol)
 
   const metrics = [
-    { label: 'Citas hoy', value: WEEK_APPOINTMENTS.filter(a => a.day === todayCols).length, icon: 'calendar' as const, color: 'var(--led)' },
+    { label: 'Citas hoy', value: appointments.filter(a => a.day === todayCols).length, icon: 'calendar' as const, color: 'var(--led)' },
     { label: 'Ingresos est.', value: '214€', icon: 'euro' as const, color: 'var(--gold)' },
     { label: 'Barberos activos', value: MOCK_BARBERS.filter(b => b.active).length, icon: 'users' as const, color: 'var(--brick-warm)' },
     { label: 'Lista de espera', value: 3, icon: 'clock' as const, color: 'var(--fg-2)' },
   ]
 
-  const upcomingToday = WEEK_APPOINTMENTS.filter(a => a.day === todayCols)
+  const upcomingToday = appointments.filter(a => a.day === todayCols)
     .sort((a, b) => a.startH * 60 + a.startM - (b.startH * 60 + b.startM))
 
   return (
@@ -109,16 +138,25 @@ export default function DashboardPage() {
         </div>
       )}
 
+      {rescheduleToast && (
+        <div
+          className="fixed top-[72px] right-3 z-[200] md:top-6 md:right-6"
+          style={{ background: 'var(--ok)', color: '#fff', padding: '0.75rem 1.25rem', borderRadius: 8, fontFamily: 'var(--font-ui)', fontSize: 14, fontWeight: 600, boxShadow: 'var(--shadow-md)' }}
+        >
+          ✓ Cita reprogramada correctamente
+        </div>
+      )}
+
       {/* Mobile-only: day agenda first, then metrics */}
       <div className="md:hidden flex flex-col gap-4 mb-4">
         {/* Day agenda — first */}
         <AgendaListView
-          items={WEEK_APPOINTMENTS.filter(a => a.day === mobileDayCol)}
+          items={appointments.filter(a => a.day === mobileDayCol)}
           barbers={MOCK_BARBERS}
           date={mobileDayDate}
           onPrevDay={() => setDayOffset(o => Math.max(o - 1, -(todayCols)))}
           onNextDay={() => setDayOffset(o => Math.min(o + 1, 5 - todayCols))}
-          onSelect={(item) => setSelectedAppt(WEEK_APPOINTMENTS.find(a => a.id === item.id) ?? null)}
+          onSelect={(item) => setSelectedAppt(appointments.find(a => a.id === item.id) ?? null)}
         />
 
         {/* Nueva cita button */}
@@ -261,7 +299,7 @@ export default function DashboardPage() {
                     />
                   )}
 
-                  {WEEK_APPOINTMENTS.filter(a => a.day === colIdx).map(appt => {
+                  {appointments.filter(a => a.day === colIdx).map(appt => {
                     const c = COLOR_MAP[appt.color]
                     return (
                       <div
@@ -396,14 +434,31 @@ export default function DashboardPage() {
                 <span style={{ fontSize: 13, color: 'var(--fg-0)', fontFamily: 'var(--font-ui)', fontWeight: 500 }}>{value}</span>
               </div>
             ))}
-            <button
-              onClick={() => setSelectedAppt(null)}
-              style={{ width: '100%', marginTop: '1rem', padding: '0.75rem', minHeight: 44, borderRadius: 8, border: '1px solid var(--line)', background: 'transparent', color: 'var(--fg-1)', fontFamily: 'var(--font-ui)', cursor: 'pointer' }}
-            >
-              Cerrar
-            </button>
+            <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+              <button
+                onClick={() => setRescheduleAppt(selectedAppt)}
+                style={{ flex: 1, padding: '0.75rem', minHeight: 44, borderRadius: 8, border: 'none', background: 'var(--led)', color: '#fff', fontFamily: 'var(--font-ui)', fontSize: 13, fontWeight: 600, cursor: 'pointer', boxShadow: 'var(--glow-led)' }}
+              >
+                Reprogramar
+              </button>
+              <button
+                onClick={() => setSelectedAppt(null)}
+                style={{ flex: 1, padding: '0.75rem', minHeight: 44, borderRadius: 8, border: '1px solid var(--line)', background: 'transparent', color: 'var(--fg-1)', fontFamily: 'var(--font-ui)', fontSize: 13, cursor: 'pointer' }}
+              >
+                Cerrar
+              </button>
+            </div>
           </div>
         </div>
+      )}
+
+      {rescheduleAppt && (
+        <RescheduleModal
+          appt={rescheduleAppt}
+          weekStart={weekStart}
+          onClose={() => setRescheduleAppt(null)}
+          onConfirm={handleRescheduleConfirm}
+        />
       )}
     </>
   )

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -3,22 +3,11 @@ import { Helmet } from 'react-helmet-async'
 import { useShopContext } from '@/context/ShopContext'
 import { Icon } from '@/components/ui'
 import { AgendaListView, NewAppointmentModal } from '@/components/admin'
+import type { WeekAppt } from '@/components/admin'
 import { MOCK_BARBERS } from '@/lib/mock-data'
 
 const DAYS_ES = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
 const HOURS = Array.from({ length: 11 }, (_, i) => i + 9) // 9 → 19
-
-interface WeekAppt {
-  id: string
-  day: number
-  startH: number
-  startM: number
-  durationMin: number
-  client: string
-  service: string
-  barberId: string
-  color: 'led' | 'brick' | 'gold'
-}
 
 const WEEK_APPOINTMENTS: WeekAppt[] = [
   { id: 'w1',  day: 0, startH: 10, startM: 0,  durationMin: 45, client: 'Carlos M.',   service: 'Corte + Barba',         barberId: 'b1', color: 'led' },

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -253,7 +253,7 @@ export default function DashboardPage() {
               {DAYS_ES.map((_, colIdx) => (
                 <div key={colIdx} style={{ borderLeft: '1px solid var(--line)', position: 'relative', minHeight: CELL_HEIGHT_PX * HOURS.length }}>
                   {HOURS.map(h => (
-                    <div key={h} style={{ height: CELL_HEIGHT_PX, borderTop: '1px solid var(--line)', opacity: 0.4 }} />
+                    <div key={h} style={{ height: CELL_HEIGHT_PX, borderTop: '1px solid var(--line)', opacity: 0.4, boxSizing: 'border-box' }} />
                   ))}
 
                   {weekOffset === 0 && colIdx === todayCols && (


### PR DESCRIPTION
## Summary
- Fix CSS: `box-sizing: border-box` en filas del calendario elimina la deriva de 1px/fila que desalineaba etiquetas de hora con líneas de cuadrícula
- Nuevo componente `RescheduleModal` con edición completa (servicio, barbero, fecha, hora) y campos prellenados con la cita actual
- Modal de detalle de cita ahora tiene botón **Reprogramar** junto a **Cerrar**
- Al confirmar, la cita se mueve en el calendario y aparece toast de confirmación

## Test plan
- [ ] Calendario semanal: líneas de hora alineadas con etiquetas
- [ ] Clicar una cita → aparecen botones "Reprogramar" y "Cerrar"
- [ ] Clicar "Reprogramar" → modal con datos actuales prellenados
- [ ] Cambiar servicio, barbero, fecha y hora → confirmar → cita en nueva posición
- [ ] Toast "✓ Cita reprogramada correctamente" visible 3 segundos

🤖 Generated with [Claude Code](https://claude.com/claude-code)