### PR TITLE
feat(calendar,admin): issues #70 y #72 — calendario, reservas y panel admin

### DIFF
--- a/src/components/admin/NewAppointmentModal.tsx
+++ b/src/components/admin/NewAppointmentModal.tsx
@@ -1,18 +1,12 @@
 import { useState } from 'react'
 import { Modal } from '@/components/ui'
-import { MonthCalendar, TimeSlots } from '@/components/calendar'
+import { MonthCalendar, TimeSlots, generateScheduleSlots } from '@/components/calendar'
 import { getBarbersAvailableForSlot } from '@/domain/booking'
 import { useServices } from '@/hooks/useServices'
 import { useBarbers } from '@/hooks/useBarbers'
+import type { WeeklySchedule, DayKey } from '@/domain/schedule'
 
-const BOOKING_SLOTS: string[] = (() => {
-  const slots: string[] = []
-  for (let h = 10; h <= 19; h++) {
-    slots.push(`${String(h).padStart(2, '0')}:00`)
-    if (h < 19) slots.push(`${String(h).padStart(2, '0')}:30`)
-  }
-  return slots
-})()
+const JS_TO_DAY: Record<number, DayKey> = { 1: 'mon', 2: 'tue', 3: 'wed', 4: 'thu', 5: 'fri', 6: 'sat', 0: 'sun' }
 
 function calcInitials(name: string): string {
   return name.trim().split(/\s+/).map(w => w[0] ?? '').join('').toUpperCase().slice(0, 2) || '?'
@@ -29,11 +23,12 @@ export interface NewAppointmentData {
 interface Props {
   onClose: () => void
   onConfirm: (data: NewAppointmentData) => void
+  schedule: WeeklySchedule
   errorMessage?: string
   isPending?: boolean
 }
 
-export function NewAppointmentModal({ onClose, onConfirm, errorMessage, isPending }: Props) {
+export function NewAppointmentModal({ onClose, onConfirm, schedule, errorMessage, isPending }: Props) {
   const today = new Date()
   const { data: services = [] } = useServices()
   const { data: barbers = [] } = useBarbers()
@@ -52,10 +47,13 @@ export function NewAppointmentModal({ onClose, onConfirm, errorMessage, isPendin
   const selectedBarber = barberId !== '__any__' ? activeBarbers.find(b => b.id === barberId) : null
   const canConfirm = email.trim().length > 3 && serviceId != null && barberId !== '' && date != null && slot != null && !isPending
 
+  const fromTime = date ? (schedule[JS_TO_DAY[date.getDay()]].from || '10:00') : '10:00'
+  const toTime = date ? (schedule[JS_TO_DAY[date.getDay()]].to || '19:00') : '19:00'
+
   const barbersToCheck = selectedBarber ? [selectedBarber] : activeBarbers
   const breakBlockedSlots = !selectedService
     ? []
-    : BOOKING_SLOTS.filter(s =>
+    : generateScheduleSlots(fromTime, toTime).filter(s =>
         getBarbersAvailableForSlot(s, selectedService.durationMinutes, barbersToCheck).length === 0,
       )
 
@@ -185,6 +183,8 @@ export function NewAppointmentModal({ onClose, onConfirm, errorMessage, isPendin
               selected={slot}
               onSelect={setSlot}
               taken={breakBlockedSlots}
+              fromTime={fromTime}
+              toTime={toTime}
             />
           </div>
         )}

--- a/src/components/admin/RescheduleModal.tsx
+++ b/src/components/admin/RescheduleModal.tsx
@@ -3,7 +3,10 @@ import { Modal } from '@/components/ui'
 import { MonthCalendar, TimeSlots } from '@/components/calendar'
 import { useServices } from '@/hooks/useServices'
 import { useBarbers } from '@/hooks/useBarbers'
+import type { WeeklySchedule, DayKey } from '@/domain/schedule'
 import type { WeekAppt, RescheduleUpdate } from './types'
+
+const JS_TO_DAY: Record<number, DayKey> = { 1: 'mon', 2: 'tue', 3: 'wed', 4: 'thu', 5: 'fri', 6: 'sat', 0: 'sun' }
 
 function calcInitials(name: string): string {
   return name.trim().split(/\s+/).map(w => w[0] ?? '').join('').toUpperCase().slice(0, 2) || '?'
@@ -12,6 +15,7 @@ function calcInitials(name: string): string {
 interface Props {
   appt: WeekAppt
   weekStart: Date
+  schedule: WeeklySchedule
   onClose: () => void
   onConfirm: (update: RescheduleUpdate) => void
 }
@@ -24,7 +28,7 @@ const LABEL: React.CSSProperties = {
   marginBottom: '0.5rem',
 }
 
-export function RescheduleModal({ appt, weekStart, onClose, onConfirm }: Props) {
+export function RescheduleModal({ appt, weekStart, schedule, onClose, onConfirm }: Props) {
   const { data: services = [] } = useServices()
   const { data: barbers = [] } = useBarbers()
   const activeServices = services.filter(s => s.isActive)
@@ -47,6 +51,9 @@ export function RescheduleModal({ appt, weekStart, onClose, onConfirm }: Props) 
   const selectedService = activeServices.find(s => s.id === serviceId)
   const selectedBarber = activeBarbers.find(b => b.id === barberId)
   const canConfirm = !!(serviceId && barberId && date && slot)
+
+  const fromTime = date ? (schedule[JS_TO_DAY[date.getDay()]].from || '10:00') : '10:00'
+  const toTime = date ? (schedule[JS_TO_DAY[date.getDay()]].to || '19:00') : '19:00'
 
   const handleConfirm = () => {
     if (!date || !slot) return
@@ -161,6 +168,8 @@ export function RescheduleModal({ appt, weekStart, onClose, onConfirm }: Props) 
               selected={slot}
               onSelect={setSlot}
               taken={[]}
+              fromTime={fromTime}
+              toTime={toTime}
             />
           </div>
         )}

--- a/src/components/appointments/ServiceCard.tsx
+++ b/src/components/appointments/ServiceCard.tsx
@@ -4,12 +4,14 @@ interface ServiceCardProps {
   service: Service
   selected: boolean
   onClick: () => void
+  disabled?: boolean
 }
 
-export function ServiceCard({ service, selected, onClick }: ServiceCardProps) {
+export function ServiceCard({ service, selected, onClick, disabled = false }: ServiceCardProps) {
   return (
     <button
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
       style={{
         width: '100%',
         textAlign: 'left',
@@ -17,14 +19,16 @@ export function ServiceCard({ service, selected, onClick }: ServiceCardProps) {
         minHeight: 44,
         borderRadius: 8,
         border: selected ? '1px solid var(--led-soft)' : '1px solid var(--line)',
-        background: selected ? 'rgba(123,79,255,0.08)' : 'var(--bg-3)',
-        cursor: 'pointer',
-        boxShadow: selected ? 'var(--glow-led)' : 'none',
+        background: disabled ? 'var(--bg-2)' : selected ? 'rgba(123,79,255,0.08)' : 'var(--bg-3)',
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        boxShadow: selected && !disabled ? 'var(--glow-led)' : 'none',
         transition: 'all 0.15s',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'space-between',
         gap: '0.75rem',
+        opacity: disabled ? 0.4 : 1,
+        position: 'relative',
       }}
     >
       <div>
@@ -36,13 +40,18 @@ export function ServiceCard({ service, selected, onClick }: ServiceCardProps) {
         }}>
           {service.name}
         </div>
-        <div style={{ display: 'flex', gap: '0.75rem', marginTop: 2 }}>
+        <div style={{ display: 'flex', gap: '0.75rem', marginTop: 2, alignItems: 'center' }}>
           <span style={{ fontSize: 11, fontFamily: 'var(--font-ui)', color: 'var(--fg-2)' }}>
             {service.durationMinutes} min
           </span>
           <span style={{ fontSize: 11, fontFamily: 'var(--font-ui)', color: 'var(--gold)' }}>
             +{service.loyaltyPoints} pts
           </span>
+          {disabled && (
+            <span style={{ fontSize: 10, fontFamily: 'var(--font-ui)', color: 'var(--fg-3)', letterSpacing: '0.05em' }}>
+              NO DISPONIBLE
+            </span>
+          )}
         </div>
       </div>
       <div style={{

--- a/src/components/calendar/MonthCalendar.tsx
+++ b/src/components/calendar/MonthCalendar.tsx
@@ -154,10 +154,10 @@ export function MonthCalendar({ selected, onSelect, month, year, onMonthChange, 
                 <div style={{
                   position: 'absolute',
                   bottom: 3,
-                  width: 4,
-                  height: 4,
+                  width: 6,
+                  height: 6,
                   borderRadius: '50%',
-                  background: isPartial ? 'var(--gold)' : 'var(--brick)',
+                  background: isPartial ? 'var(--gold)' : 'var(--led)',
                 }} />
               )}
             </button>

--- a/src/components/calendar/TimeSlots.tsx
+++ b/src/components/calendar/TimeSlots.tsx
@@ -2,23 +2,30 @@ interface TimeSlotsProps {
   selected: string | null
   onSelect: (slot: string) => void
   taken?: string[]
+  fromTime?: string
+  toTime?: string
 }
 
-function generateSlots() {
+export function generateScheduleSlots(from = '10:00', to = '19:00'): string[] {
+  const [fromH, fromM] = from.split(':').map(Number)
+  const [toH, toM] = to.split(':').map(Number)
+  const toMinutes = toH * 60 + toM
   const slots: string[] = []
-  for (let h = 10; h <= 19; h++) {
-    slots.push(`${h.toString().padStart(2, '0')}:00`)
-    if (h < 19) slots.push(`${h.toString().padStart(2, '0')}:30`)
+  let minutes = fromH * 60 + fromM
+  while (minutes < toMinutes) {
+    const h = Math.floor(minutes / 60)
+    const m = minutes % 60
+    slots.push(`${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`)
+    minutes += 30
   }
   return slots
 }
 
-const ALL_SLOTS = generateSlots()
-
-export function TimeSlots({ selected, onSelect, taken = [] }: TimeSlotsProps) {
+export function TimeSlots({ selected, onSelect, taken = [], fromTime, toTime }: TimeSlotsProps) {
+  const slots = generateScheduleSlots(fromTime, toTime)
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-1.5">
-      {ALL_SLOTS.map(slot => {
+      {slots.map(slot => {
         const isTaken = taken.includes(slot)
         const isSelected = selected === slot
 

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -1,2 +1,2 @@
 export { MonthCalendar } from './MonthCalendar'
-export { TimeSlots } from './TimeSlots'
+export { TimeSlots, generateScheduleSlots } from './TimeSlots'

--- a/src/domain/appointment/index.ts
+++ b/src/domain/appointment/index.ts
@@ -6,6 +6,7 @@ export const CANCELLATION_LIMIT_HOURS = 2
 export interface Appointment {
   id: string
   clientId: string
+  clientName?: string
   barberId: string
   serviceId: string
   /** ISO datetime string */
@@ -36,10 +37,18 @@ export function canCancelAppointment(
   return start - nowTimestamp > limitMs
 }
 
+export interface UpdateAppointmentData {
+  startTime: string
+  endTime: string
+  barberId: string
+  serviceId: string
+}
+
 export interface IAppointmentRepository {
   getForClient(clientId: string): Promise<Appointment[]>
   getAll(): Promise<Appointment[]>
   create(data: CreateAppointmentData): Promise<Appointment>
   cancel(id: string): Promise<void>
   updateStatus(id: string, status: AppointmentStatus): Promise<void>
+  updateAppointment(id: string, data: UpdateAppointmentData): Promise<void>
 }

--- a/src/domain/barber/index.ts
+++ b/src/domain/barber/index.ts
@@ -36,6 +36,7 @@ export interface UpdateBarberData {
 export interface IBarberRepository {
   getActive(): Promise<Barber[]>
   getAll(): Promise<Barber[]>
+  findByEmail(email: string): Promise<Barber | null>
   create(data: CreateBarberData): Promise<Barber>
   update(id: string, data: UpdateBarberData): Promise<Barber>
   delete(id: string): Promise<void>

--- a/src/domain/service/index.ts
+++ b/src/domain/service/index.ts
@@ -6,6 +6,7 @@ export interface Service {
   price: number
   loyaltyPoints: number
   isActive: boolean
+  isDeleted: boolean
   sortOrder: number
 }
 
@@ -34,4 +35,6 @@ export interface IServiceRepository {
   create(data: CreateServiceData): Promise<Service>
   update(id: string, data: UpdateServiceData): Promise<Service>
   delete(id: string): Promise<void>
+  reactivate(id: string): Promise<void>
+  softDelete(id: string): Promise<void>
 }

--- a/src/hooks/useAppointments.ts
+++ b/src/hooks/useAppointments.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { repositories } from '@/infrastructure'
-import type { CreateAppointmentData, AppointmentStatus } from '@/domain/appointment'
+import type { CreateAppointmentData, AppointmentStatus, UpdateAppointmentData } from '@/domain/appointment'
 import { queryKeys, STALE } from './queryKeys'
 
 /** Client view: returns appointments for the given user */
@@ -46,6 +46,15 @@ export function useUpdateAppointmentStatus() {
   return useMutation({
     mutationFn: ({ id, status }: { id: string; status: AppointmentStatus }) =>
       repositories.appointments().updateStatus(id, status),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.appointments.all() }),
+  })
+}
+
+export function useUpdateAppointment() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateAppointmentData }) =>
+      repositories.appointments().updateAppointment(id, data),
     onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.appointments.all() }),
   })
 }

--- a/src/hooks/useBarbers.ts
+++ b/src/hooks/useBarbers.ts
@@ -48,6 +48,12 @@ export function useAddBarberByEmail() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (email: string) => {
+      const existing = await repositories.barbers().findByEmail(email)
+      if (existing) {
+        if (existing.isActive) throw new Error('Ya existe un barbero con ese email')
+        await repositories.barbers().update(existing.id, { isActive: true })
+        return
+      }
       const profile = await repositories.profiles().findByEmailFull(email)
       if (!profile) throw new Error('Email no registrado')
       // Role update first — if create fails, the role is already correct and the

--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -43,3 +43,19 @@ export function useDeleteService() {
     onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.services.all() }),
   })
 }
+
+export function useReactivateService() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => repositories.services().reactivate(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.services.all() }),
+  })
+}
+
+export function useSoftDeleteService() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => repositories.services().softDelete(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.services.all() }),
+  })
+}

--- a/src/infrastructure/insforge/appointmentRepository.ts
+++ b/src/infrastructure/insforge/appointmentRepository.ts
@@ -3,6 +3,7 @@ import type {
   Appointment,
   AppointmentStatus,
   CreateAppointmentData,
+  UpdateAppointmentData,
 } from '@/domain/appointment'
 import { insforgeClient } from './client'
 
@@ -16,12 +17,14 @@ interface AppointmentRow {
   status: string
   notes: string | null
   created_at: string
+  profiles?: { full_name: string | null }[] | null
 }
 
 function mapToAppointment(row: AppointmentRow): Appointment {
   return {
     id: row.id,
     clientId: row.client_id,
+    clientName: row.profiles?.[0]?.full_name ?? undefined,
     barberId: row.barber_id,
     serviceId: row.service_id,
     startTime: row.start_time,
@@ -34,6 +37,9 @@ function mapToAppointment(row: AppointmentRow): Appointment {
 
 const SELECT_FIELDS =
   'id, client_id, barber_id, service_id, start_time, end_time, status, notes, created_at'
+
+const SELECT_FIELDS_WITH_CLIENT =
+  'id, client_id, barber_id, service_id, start_time, end_time, status, notes, created_at, profiles!appointments_client_id_fkey(full_name)'
 
 export class InsForgeAppointmentRepository implements IAppointmentRepository {
   async getForClient(clientId: string): Promise<Appointment[]> {
@@ -49,7 +55,7 @@ export class InsForgeAppointmentRepository implements IAppointmentRepository {
   async getAll(): Promise<Appointment[]> {
     const { data, error } = await insforgeClient.database
       .from('appointments')
-      .select(SELECT_FIELDS)
+      .select(SELECT_FIELDS_WITH_CLIENT)
       .order('start_time', { ascending: false })
     if (error) throw error
     return ((data ?? []) as AppointmentRow[]).map(mapToAppointment)
@@ -84,6 +90,19 @@ export class InsForgeAppointmentRepository implements IAppointmentRepository {
     const { error } = await insforgeClient.database
       .from('appointments')
       .update({ status })
+      .eq('id', id)
+    if (error) throw error
+  }
+
+  async updateAppointment(id: string, data: UpdateAppointmentData): Promise<void> {
+    const { error } = await insforgeClient.database
+      .from('appointments')
+      .update({
+        start_time: data.startTime,
+        end_time: data.endTime,
+        barber_id: data.barberId,
+        service_id: data.serviceId,
+      })
       .eq('id', id)
     if (error) throw error
   }

--- a/src/infrastructure/insforge/appointmentRepository.ts
+++ b/src/infrastructure/insforge/appointmentRepository.ts
@@ -39,7 +39,7 @@ const SELECT_FIELDS =
   'id, client_id, barber_id, service_id, start_time, end_time, status, notes, created_at'
 
 const SELECT_FIELDS_WITH_CLIENT =
-  'id, client_id, barber_id, service_id, start_time, end_time, status, notes, created_at, profiles!appointments_client_id_fkey(full_name)'
+  'id, client_id, barber_id, service_id, start_time, end_time, status, notes, created_at, profiles(full_name)'
 
 export class InsForgeAppointmentRepository implements IAppointmentRepository {
   async getForClient(clientId: string): Promise<Appointment[]> {

--- a/src/infrastructure/insforge/barberRepository.ts
+++ b/src/infrastructure/insforge/barberRepository.ts
@@ -52,6 +52,17 @@ export class InsForgeBarberRepository implements IBarberRepository {
     return ((data ?? []) as BarberRow[]).map(mapToBarber)
   }
 
+  async findByEmail(email: string): Promise<Barber | null> {
+    const { data, error } = await insforgeClient.database
+      .from('barbers')
+      .select(SELECT)
+      .eq('email', email)
+      .limit(1)
+    if (error) throw error
+    const rows = (data ?? []) as BarberRow[]
+    return rows.length > 0 ? mapToBarber(rows[0]) : null
+  }
+
   async create(data: CreateBarberData): Promise<Barber> {
     // InsForge does not support ?select on POST — insert without returning clause.
     // The caller (useAddBarberByEmail) ignores the return value and invalidates

--- a/src/infrastructure/insforge/serviceRepository.ts
+++ b/src/infrastructure/insforge/serviceRepository.ts
@@ -9,10 +9,11 @@ interface ServiceRow {
   price: number | string
   loyalty_points: number
   is_active: boolean
+  is_deleted: boolean
   sort_order: number
 }
 
-const SELECT = 'id, name, description, duration_minutes, price, loyalty_points, is_active, sort_order'
+const SELECT = 'id, name, description, duration_minutes, price, loyalty_points, is_active, is_deleted, sort_order'
 
 function mapToService(row: ServiceRow): Service {
   return {
@@ -23,6 +24,7 @@ function mapToService(row: ServiceRow): Service {
     price: Number(row.price),
     loyaltyPoints: row.loyalty_points,
     isActive: row.is_active,
+    isDeleted: row.is_deleted,
     sortOrder: row.sort_order,
   }
 }
@@ -33,6 +35,7 @@ export class InsForgeServiceRepository implements IServiceRepository {
       .from('services')
       .select(SELECT)
       .eq('is_active', true)
+      .eq('is_deleted', false)
       .order('sort_order')
     if (error) throw error
     return ((data ?? []) as ServiceRow[]).map(mapToService)
@@ -42,6 +45,7 @@ export class InsForgeServiceRepository implements IServiceRepository {
     const { data, error } = await insforgeClient.database
       .from('services')
       .select(SELECT)
+      .eq('is_deleted', false)
       .order('sort_order')
     if (error) throw error
     return ((data ?? []) as ServiceRow[]).map(mapToService)
@@ -58,6 +62,7 @@ export class InsForgeServiceRepository implements IServiceRepository {
         description: data.description ?? null,
         sort_order: data.sortOrder ?? 99,
         is_active: true,
+        is_deleted: false,
       })
       .select(SELECT)
       .single()
@@ -86,10 +91,27 @@ export class InsForgeServiceRepository implements IServiceRepository {
   }
 
   async delete(id: string): Promise<void> {
-    // Soft-delete — bypass update() to avoid chaining .select() on the PATCH request.
+    // Deactivate — prevents new bookings but existing appointments complete
     const { error } = await insforgeClient.database
       .from('services')
       .update({ is_active: false })
+      .eq('id', id)
+    if (error) throw error
+  }
+
+  async reactivate(id: string): Promise<void> {
+    const { error } = await insforgeClient.database
+      .from('services')
+      .update({ is_active: true })
+      .eq('id', id)
+    if (error) throw error
+  }
+
+  async softDelete(id: string): Promise<void> {
+    // Permanently hides the service — only safe when no active appointments remain
+    const { error } = await insforgeClient.database
+      .from('services')
+      .update({ is_deleted: true })
       .eq('id', id)
     if (error) throw error
   }

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef, useSyncExternalStore } from 'react'
+import { useState, useMemo, useEffect, useRef, useSyncExternalStore } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
 import { useShopContext } from '@/context/ShopContext'
 import { Icon } from '@/components/ui'
@@ -9,6 +10,8 @@ import { useAllServices } from '@/hooks/useServices'
 import { useAllAppointments, useCreateAppointment, useFindProfileByEmail } from '@/hooks/useAppointments'
 import { useWeeklySchedule } from '@/hooks/useSchedule'
 import { DEFAULT_WEEKLY_SCHEDULE } from '@/domain/schedule'
+import { repositories } from '@/infrastructure'
+import { queryKeys } from '@/hooks/queryKeys'
 
 const landscapeMq = typeof window !== 'undefined'
   ? window.matchMedia('(orientation: landscape) and (max-height: 600px)')
@@ -25,26 +28,7 @@ function useLandscape() {
 const DAYS_ES = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom']
 const HOURS = Array.from({ length: 11 }, (_, i) => i + 9) // 9 → 19
 
-const INITIAL_APPOINTMENTS: WeekAppt[] = [
-  { id: 'w1',  day: 0, startH: 10, startM: 0,  durationMin: 45, client: 'Carlos M.',   service: 'Corte + Barba',         barberId: 'b1', color: 'led' },
-  { id: 'w2',  day: 0, startH: 11, startM: 30, durationMin: 30, client: 'Rubén G.',    service: 'Corte Clásico',          barberId: 'b2', color: 'brick' },
-  { id: 'w3',  day: 0, startH: 14, startM: 0,  durationMin: 60, client: 'Javier P.',   service: 'Corte Premium',          barberId: 'b1', color: 'led' },
-  { id: 'w4',  day: 1, startH: 9,  startM: 30, durationMin: 45, client: 'Miguel Á.',   service: 'Corte + Barba',         barberId: 'b2', color: 'brick' },
-  { id: 'w5',  day: 1, startH: 11, startM: 0,  durationMin: 30, client: 'Toni R.',     service: 'Afeitado Tradicional',   barberId: 'b1', color: 'gold' },
-  { id: 'w6',  day: 1, startH: 16, startM: 0,  durationMin: 75, client: 'Álex F.',     service: 'Tinte + Corte',          barberId: 'b2', color: 'brick' },
-  { id: 'w7',  day: 2, startH: 10, startM: 30, durationMin: 30, client: 'Marc V.',     service: 'Corte Clásico',          barberId: 'b1', color: 'led' },
-  { id: 'w8',  day: 2, startH: 12, startM: 0,  durationMin: 45, client: 'Sergio L.',   service: 'Corte + Barba',         barberId: 'b2', color: 'brick' },
-  { id: 'w9',  day: 2, startH: 15, startM: 30, durationMin: 60, client: 'Iván M.',     service: 'Corte Premium',          barberId: 'b1', color: 'led' },
-  { id: 'w10', day: 3, startH: 9,  startM: 0,  durationMin: 25, client: 'Leo (niño)',  service: 'Niños (-12)',            barberId: 'b2', color: 'gold' },
-  { id: 'w11', day: 3, startH: 11, startM: 30, durationMin: 45, client: 'Raúl C.',     service: 'Corte + Barba',         barberId: 'b1', color: 'led' },
-  { id: 'w12', day: 3, startH: 17, startM: 0,  durationMin: 30, client: 'Paco G.',     service: 'Afeitado Tradicional',   barberId: 'b2', color: 'gold' },
-  { id: 'w13', day: 4, startH: 10, startM: 0,  durationMin: 30, client: 'Daniel H.',   service: 'Corte Clásico',          barberId: 'b1', color: 'brick' },
-  { id: 'w14', day: 4, startH: 13, startM: 0,  durationMin: 75, client: 'Omar S.',     service: 'Tinte + Corte',          barberId: 'b2', color: 'brick' },
-  { id: 'w15', day: 4, startH: 16, startM: 30, durationMin: 45, client: 'Dani R.',     service: 'Corte + Barba',         barberId: 'b1', color: 'led' },
-  { id: 'w16', day: 5, startH: 9,  startM: 30, durationMin: 30, client: 'Vicent M.',   service: 'Corte Clásico',          barberId: 'b2', color: 'gold' },
-  { id: 'w17', day: 5, startH: 10, startM: 30, durationMin: 60, client: 'Lucas B.',    service: 'Corte Premium',          barberId: 'b1', color: 'led' },
-  { id: 'w18', day: 5, startH: 12, startM: 0,  durationMin: 45, client: 'Andrés T.',   service: 'Corte + Barba',         barberId: 'b2', color: 'brick' },
-]
+const APPT_COLORS = ['led', 'brick', 'gold'] as const
 
 const COLOR_MAP = {
   led:   { bg: 'rgba(123,79,255,0.18)',  border: 'var(--led)',       text: 'var(--led-soft)' },
@@ -91,10 +75,10 @@ export default function DashboardPage() {
   const { data: schedule = DEFAULT_WEEKLY_SCHEDULE } = useWeeklySchedule()
   const createApptMut = useCreateAppointment()
   const findProfileByEmail = useFindProfileByEmail()
+  const qc = useQueryClient()
   const activeBarbers = barbers.filter(b => b.isActive)
   const [weekOffset, setWeekOffset] = useState(0)
   const [dayOffset, setDayOffset] = useState(0)
-  const [appointments, setAppointments] = useState<WeekAppt[]>(INITIAL_APPOINTMENTS)
   const [selectedAppt, setSelectedAppt] = useState<WeekAppt | null>(null)
   const [rescheduleAppt, setRescheduleAppt] = useState<WeekAppt | null>(null)
   const [newApptOpen, setNewApptOpen] = useState(false)
@@ -102,6 +86,36 @@ export default function DashboardPage() {
   const [rescheduleToast, setRescheduleToast] = useState(false)
   const [apptError, setApptError] = useState<string | null>(null)
   const nowLineRef = useRef<HTMLDivElement>(null)
+
+  const weekStart = useMemo(() => {
+    const ws = getWeekStart(new Date())
+    ws.setDate(ws.getDate() + weekOffset * 7)
+    return ws
+  }, [weekOffset])
+
+  const appointments = useMemo<WeekAppt[]>(() => {
+    return dbAppointments
+      .filter(a => a.status !== 'cancelled' && a.status !== 'no_show')
+      .flatMap((a, i) => {
+        const start = new Date(a.startTime)
+        const end = new Date(a.endTime)
+        const dayDiff = Math.round((start.getTime() - weekStart.getTime()) / 86_400_000)
+        if (dayDiff < 0 || dayDiff > 6) return []
+        const svc = services.find(s => s.id === a.serviceId)
+        const barberIdx = barbers.findIndex(b => b.id === a.barberId)
+        return [{
+          id: a.id,
+          day: dayDiff,
+          startH: start.getHours(),
+          startM: start.getMinutes(),
+          durationMin: Math.round((end.getTime() - start.getTime()) / 60_000),
+          client: a.clientName ?? `Cliente ${a.clientId.slice(0, 6)}`,
+          service: svc?.name ?? 'Servicio',
+          barberId: a.barberId,
+          color: APPT_COLORS[barberIdx >= 0 ? barberIdx % 3 : i % 3],
+        } satisfies WeekAppt]
+      })
+  }, [dbAppointments, weekStart, services, barbers])
 
   const handleNewApptConfirm = async (data: NewAppointmentData) => {
     setApptError(null)
@@ -158,32 +172,26 @@ export default function DashboardPage() {
 
   const handleRescheduleConfirm = async (update: RescheduleUpdate) => {
     if (!rescheduleAppt) return
-    const [newH, newM] = update.slot.split(':').map(Number)
-    const newDayIdx = Math.round((update.date.getTime() - weekStart.getTime()) / 86_400_000)
-    const newService = services.find(s => s.id === update.serviceId)?.name ?? rescheduleAppt.service
-
-    setAppointments(prev => prev.map(a =>
-      a.id === rescheduleAppt.id
-        ? { ...a, day: newDayIdx, startH: newH, startM: newM, service: newService, barberId: update.barberId }
-        : a
-    ))
+    const svc = services.find(s => s.id === update.serviceId)
+    if (!svc) return
+    const startDt = combineDateSlot(update.date, update.slot)
+    const endDt = addMinutes(startDt, svc.durationMinutes)
 
     try {
-      await fetch(`/rest/v1/appointments?id=eq.${rescheduleAppt.id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ scheduled_at: update.date.toISOString() }),
+      await repositories.appointments().updateAppointment(rescheduleAppt.id, {
+        startTime: startDt.toISOString(),
+        endTime: endDt.toISOString(),
+        barberId: update.barberId,
+        serviceId: update.serviceId,
       })
-    } catch { /* ignorar */ }
+      await qc.invalidateQueries({ queryKey: queryKeys.appointments.all() })
+    } catch { /* silencio — toast no se muestra si falla */ }
 
     setRescheduleAppt(null)
     setSelectedAppt(null)
     setRescheduleToast(true)
     setTimeout(() => setRescheduleToast(false), 3000)
   }
-
-  const weekStart = getWeekStart(new Date())
-  weekStart.setDate(weekStart.getDate() + weekOffset * 7)
 
   const now = new Date()
   const nowTop = Math.min(topPx(now.getHours(), now.getMinutes()), MAX_TOP_PX)
@@ -327,7 +335,7 @@ export default function DashboardPage() {
 
           {/* Grid body — horizontal scroll only needed in portrait narrow screens */}
           <div style={{ overflowX: isLandscape ? 'hidden' : 'auto' }}>
-          <div style={{ maxHeight: isLandscape ? 'calc(100dvh - 140px)' : 520, overflowY: 'auto', minWidth: isLandscape ? undefined : 600 }}>
+          <div style={{ maxHeight: isLandscape ? 'calc(100dvh - 140px)' : 'calc(100dvh - 200px)', overflowY: 'auto', minWidth: isLandscape ? undefined : 600 }}>
             {/* Day headers — sticky so scrollbar width is shared with the content grid */}
             <div style={{ display: 'grid', gridTemplateColumns: '52px repeat(7, 1fr)', borderBottom: '1px solid var(--line)', position: 'sticky', top: 0, zIndex: 10, background: 'var(--bg-2)' }}>
               <div />

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useMemo, useEffect, useRef, useSyncExternalStore } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
 import { Helmet } from 'react-helmet-async'
 import { useShopContext } from '@/context/ShopContext'
 import { Icon } from '@/components/ui'
@@ -7,11 +6,9 @@ import { AgendaListView, NewAppointmentModal, RescheduleModal } from '@/componen
 import type { WeekAppt, RescheduleUpdate, NewAppointmentData } from '@/components/admin'
 import { useBarbers } from '@/hooks/useBarbers'
 import { useAllServices } from '@/hooks/useServices'
-import { useAllAppointments, useCreateAppointment, useFindProfileByEmail } from '@/hooks/useAppointments'
+import { useAllAppointments, useCreateAppointment, useUpdateAppointment, useFindProfileByEmail } from '@/hooks/useAppointments'
 import { useWeeklySchedule } from '@/hooks/useSchedule'
 import { DEFAULT_WEEKLY_SCHEDULE } from '@/domain/schedule'
-import { repositories } from '@/infrastructure'
-import { queryKeys } from '@/hooks/queryKeys'
 
 const landscapeMq = typeof window !== 'undefined'
   ? window.matchMedia('(orientation: landscape) and (max-height: 600px)')
@@ -74,8 +71,8 @@ export default function DashboardPage() {
   const { data: dbAppointments = [] } = useAllAppointments()
   const { data: schedule = DEFAULT_WEEKLY_SCHEDULE } = useWeeklySchedule()
   const createApptMut = useCreateAppointment()
+  const updateApptMut = useUpdateAppointment()
   const findProfileByEmail = useFindProfileByEmail()
-  const qc = useQueryClient()
   const activeBarbers = barbers.filter(b => b.isActive)
   const [weekOffset, setWeekOffset] = useState(0)
   const [dayOffset, setDayOffset] = useState(0)
@@ -170,27 +167,24 @@ export default function DashboardPage() {
     )
   }
 
-  const handleRescheduleConfirm = async (update: RescheduleUpdate) => {
+  const handleRescheduleConfirm = (update: RescheduleUpdate) => {
     if (!rescheduleAppt) return
     const svc = services.find(s => s.id === update.serviceId)
     if (!svc) return
     const startDt = combineDateSlot(update.date, update.slot)
     const endDt = addMinutes(startDt, svc.durationMinutes)
 
-    try {
-      await repositories.appointments().updateAppointment(rescheduleAppt.id, {
-        startTime: startDt.toISOString(),
-        endTime: endDt.toISOString(),
-        barberId: update.barberId,
-        serviceId: update.serviceId,
-      })
-      await qc.invalidateQueries({ queryKey: queryKeys.appointments.all() })
-    } catch { /* silencio — toast no se muestra si falla */ }
-
-    setRescheduleAppt(null)
-    setSelectedAppt(null)
-    setRescheduleToast(true)
-    setTimeout(() => setRescheduleToast(false), 3000)
+    updateApptMut.mutate(
+      { id: rescheduleAppt.id, data: { startTime: startDt.toISOString(), endTime: endDt.toISOString(), barberId: update.barberId, serviceId: update.serviceId } },
+      {
+        onSuccess: () => {
+          setRescheduleAppt(null)
+          setSelectedAppt(null)
+          setRescheduleToast(true)
+          setTimeout(() => setRescheduleToast(false), 3000)
+        },
+      },
+    )
   }
 
   const now = new Date()

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -7,6 +7,8 @@ import type { WeekAppt, RescheduleUpdate, NewAppointmentData } from '@/component
 import { useBarbers } from '@/hooks/useBarbers'
 import { useAllServices } from '@/hooks/useServices'
 import { useAllAppointments, useCreateAppointment, useFindProfileByEmail } from '@/hooks/useAppointments'
+import { useWeeklySchedule } from '@/hooks/useSchedule'
+import { DEFAULT_WEEKLY_SCHEDULE } from '@/domain/schedule'
 
 const landscapeMq = typeof window !== 'undefined'
   ? window.matchMedia('(orientation: landscape) and (max-height: 600px)')
@@ -86,6 +88,7 @@ export default function DashboardPage() {
   const { data: barbers = [] } = useBarbers()
   const { data: services = [] } = useAllServices()
   const { data: dbAppointments = [] } = useAllAppointments()
+  const { data: schedule = DEFAULT_WEEKLY_SCHEDULE } = useWeeklySchedule()
   const createApptMut = useCreateAppointment()
   const findProfileByEmail = useFindProfileByEmail()
   const activeBarbers = barbers.filter(b => b.isActive)
@@ -505,6 +508,7 @@ export default function DashboardPage() {
         <NewAppointmentModal
           onClose={() => { setNewApptOpen(false); setApptError(null) }}
           onConfirm={handleNewApptConfirm}
+          schedule={schedule}
           errorMessage={apptError ?? undefined}
           isPending={createApptMut.isPending}
         />
@@ -557,6 +561,7 @@ export default function DashboardPage() {
         <RescheduleModal
           appt={rescheduleAppt}
           weekStart={weekStart}
+          schedule={schedule}
           onClose={() => setRescheduleAppt(null)}
           onConfirm={handleRescheduleConfirm}
         />

--- a/src/pages/admin/DashboardPage.tsx
+++ b/src/pages/admin/DashboardPage.tsx
@@ -211,6 +211,38 @@ export default function DashboardPage() {
   const upcomingToday = appointments.filter(a => a.day === todayCols)
     .sort((a, b) => a.startH * 60 + a.startM - (b.startH * 60 + b.startM))
 
+  const landscapeRows = useMemo(() => {
+    const todayDate = new Date()
+    todayDate.setHours(0, 0, 0, 0)
+    const tomorrowDate = new Date(todayDate)
+    tomorrowDate.setDate(tomorrowDate.getDate() + 1)
+    const todayStr = todayDate.toISOString().slice(0, 10)
+    const tomorrowStr = tomorrowDate.toISOString().slice(0, 10)
+    const base = dbAppointments.filter(a => a.status !== 'cancelled' && a.status !== 'no_show')
+    const mapAppts = (dateStr: string): WeekAppt[] =>
+      base
+        .filter(a => new Date(a.startTime).toISOString().slice(0, 10) === dateStr)
+        .map((a, i) => {
+          const start = new Date(a.startTime)
+          const end = new Date(a.endTime)
+          const svc = services.find(s => s.id === a.serviceId)
+          const barberIdx = barbers.findIndex(b => b.id === a.barberId)
+          return {
+            id: a.id, day: 0,
+            startH: start.getHours(), startM: start.getMinutes(),
+            durationMin: Math.round((end.getTime() - start.getTime()) / 60_000),
+            client: a.clientName ?? `Cliente ${a.clientId.slice(0, 6)}`,
+            service: svc?.name ?? 'Servicio',
+            barberId: a.barberId,
+            color: APPT_COLORS[barberIdx >= 0 ? barberIdx % 3 : i % 3],
+          } satisfies WeekAppt
+        })
+    return [
+      { label: 'Hoy',    date: todayDate,    appts: mapAppts(todayStr) },
+      { label: 'Mañana', date: tomorrowDate, appts: mapAppts(tomorrowStr) },
+    ]
+  }, [dbAppointments, services, barbers])
+
   return (
     <>
       <Helmet><title>Agenda — {shopName}</title></Helmet>
@@ -327,121 +359,161 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          {/* Grid body — horizontal scroll only needed in portrait narrow screens */}
-          <div style={{ overflowX: isLandscape ? 'hidden' : 'auto' }}>
-          <div style={{ maxHeight: isLandscape ? 'calc(100dvh - 140px)' : 'calc(100dvh - 200px)', overflowY: 'auto', minWidth: isLandscape ? undefined : 600 }}>
-            {/* Day headers — sticky so scrollbar width is shared with the content grid */}
-            <div style={{ display: 'grid', gridTemplateColumns: '52px repeat(7, 1fr)', borderBottom: '1px solid var(--line)', position: 'sticky', top: 0, zIndex: 10, background: 'var(--bg-2)' }}>
-              <div />
-              {DAYS_ES.map((d, i) => {
-                const dayDate = new Date(weekStart)
-                dayDate.setDate(dayDate.getDate() + i)
-                const isToday = weekOffset === 0 && i === todayCols
-                return (
-                  <div key={d} style={{ padding: '0.6rem 0', textAlign: 'center', borderLeft: '1px solid var(--line)' }}>
-                    <div style={{ fontSize: 10, color: 'var(--fg-3)', fontFamily: 'var(--font-ui)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>{d}</div>
-                    <div style={{
-                      fontFamily: 'var(--font-display)', fontSize: 20,
-                      color: isToday ? 'var(--led-soft)' : 'var(--fg-0)',
-                      lineHeight: 1.1,
-                      textShadow: isToday ? '0 0 16px rgba(123,79,255,0.5)' : 'none',
-                    }}>
-                      {dayDate.getDate()}
+          {/* Grid body */}
+          {isLandscape ? (
+            /* Landscape mobile: 2 days (today + tomorrow), hours on X axis */
+            <div style={{ overflowX: 'auto' }}>
+              <div style={{ minWidth: 560 }}>
+                {/* Hour header row */}
+                <div style={{ display: 'flex', borderBottom: '1px solid var(--line)', background: 'var(--bg-2)' }}>
+                  <div style={{ width: 56, flexShrink: 0 }} />
+                  {HOURS.map(h => (
+                    <div key={h} style={{ flex: 1, textAlign: 'center', padding: '0.3rem 0', fontSize: 9, color: 'var(--fg-3)', fontFamily: 'var(--font-mono, monospace)' }}>
+                      {h}:00
                     </div>
-                  </div>
-                )
-              })}
-            </div>
-
-            <div style={{ display: 'grid', gridTemplateColumns: '52px repeat(7, 1fr)', position: 'relative' }}>
-              {/* Hour labels */}
-              <div>
-                {HOURS.map(h => (
-                  <div key={h} style={{ height: CELL_HEIGHT_PX, display: 'flex', alignItems: 'flex-start', justifyContent: 'flex-end', paddingRight: 8, paddingTop: 4 }}>
-                    <span style={{ fontSize: 10, color: 'var(--fg-3)', fontFamily: 'var(--font-mono, monospace)' }}>{h}:00</span>
+                  ))}
+                </div>
+                {/* Day rows */}
+                {landscapeRows.map(({ label, date, appts }) => (
+                  <div key={label} style={{ display: 'flex', height: 68, borderBottom: '1px solid var(--line)' }}>
+                    <div style={{ width: 56, flexShrink: 0, display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center', borderRight: '1px solid var(--line)', gap: 2 }}>
+                      <div style={{ fontSize: 8, color: 'var(--fg-3)', fontFamily: 'var(--font-ui)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>{label}</div>
+                      <div style={{ fontFamily: 'var(--font-display)', fontSize: 18, color: label === 'Hoy' ? 'var(--led-soft)' : 'var(--fg-0)', lineHeight: 1 }}>{date.getDate()}</div>
+                    </div>
+                    <div style={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
+                      {/* Vertical hour grid lines */}
+                      {HOURS.slice(1).map((_, i) => (
+                        <div key={i} style={{ position: 'absolute', top: 0, bottom: 0, left: `${(i + 1) / HOURS.length * 100}%`, width: 1, background: 'var(--line)', opacity: 0.3, pointerEvents: 'none' }} />
+                      ))}
+                      {/* Appointments */}
+                      {appts.map(appt => {
+                        const c = COLOR_MAP[appt.color]
+                        const leftPct = Math.max(0, (appt.startH - DAY_START_H + appt.startM / 60) / HOURS.length * 100)
+                        const widthPct = Math.max(2, (appt.durationMin / 60) / HOURS.length * 100)
+                        return (
+                          <div key={appt.id} onClick={() => setSelectedAppt(appt)} style={{
+                            position: 'absolute', top: 4, bottom: 4,
+                            left: `${leftPct}%`, width: `${widthPct}%`,
+                            background: c.bg, border: `1px solid ${c.border}`,
+                            borderRadius: 4, padding: '2px 4px',
+                            cursor: 'pointer', overflow: 'hidden', zIndex: 4,
+                          }}>
+                            <div style={{ fontSize: 9, fontWeight: 700, color: c.text, lineHeight: 1.2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                              {appt.startH.toString().padStart(2,'0')}:{appt.startM.toString().padStart(2,'0')} {appt.client}
+                            </div>
+                          </div>
+                        )
+                      })}
+                    </div>
                   </div>
                 ))}
               </div>
-
-              {/* Day columns */}
-              {DAYS_ES.map((_, colIdx) => (
-                <div key={colIdx} style={{ borderLeft: '1px solid var(--line)', position: 'relative', minHeight: CELL_HEIGHT_PX * HOURS.length }}>
-                  {HOURS.map(h => (
-                    <div key={h} style={{ height: CELL_HEIGHT_PX, borderTop: '1px solid var(--line)', opacity: 0.4, boxSizing: 'border-box' }} />
-                  ))}
-
-                  {weekOffset === 0 && colIdx === todayCols && (
-                    <div
-                      ref={nowLineRef}
-                      style={{
-                        position: 'absolute',
-                        left: 0, right: 0,
-                        top: nowTop,
-                        height: 2,
-                        background: 'var(--led)',
-                        boxShadow: '0 0 0 1px rgba(255,255,255,0.55), 0 0 8px rgba(123,79,255,0.8)',
-                        zIndex: 5,
-                        pointerEvents: 'none',
-                      }}
-                    >
-                      <span style={{
-                        position: 'absolute',
-                        left: 2,
-                        top: -18,
-                        fontSize: 9,
-                        fontFamily: 'var(--font-ui)',
-                        color: 'var(--led)',
-                        fontWeight: 600,
-                        letterSpacing: '0.04em',
-                        lineHeight: 1,
-                        pointerEvents: 'none',
-                        whiteSpace: 'nowrap',
+            </div>
+          ) : (
+            /* Portrait/desktop: 7-day grid */
+            <div style={{ overflowX: 'auto' }}>
+            <div style={{ maxHeight: 'calc(100dvh - 200px)', overflowY: 'auto', minWidth: 600 }}>
+              {/* Day headers */}
+              <div style={{ display: 'grid', gridTemplateColumns: '52px repeat(7, 1fr)', borderBottom: '1px solid var(--line)', position: 'sticky', top: 0, zIndex: 10, background: 'var(--bg-2)' }}>
+                <div />
+                {DAYS_ES.map((d, i) => {
+                  const dayDate = new Date(weekStart)
+                  dayDate.setDate(dayDate.getDate() + i)
+                  const isToday = weekOffset === 0 && i === todayCols
+                  return (
+                    <div key={d} style={{ padding: '0.6rem 0', textAlign: 'center', borderLeft: '1px solid var(--line)' }}>
+                      <div style={{ fontSize: 10, color: 'var(--fg-3)', fontFamily: 'var(--font-ui)', textTransform: 'uppercase', letterSpacing: '0.08em' }}>{d}</div>
+                      <div style={{
+                        fontFamily: 'var(--font-display)', fontSize: 20,
+                        color: isToday ? 'var(--led-soft)' : 'var(--fg-0)',
+                        lineHeight: 1.1,
+                        textShadow: isToday ? '0 0 16px rgba(123,79,255,0.5)' : 'none',
                       }}>
-                        {now.getHours().toString().padStart(2, '0')}:{now.getMinutes().toString().padStart(2, '0')}
-                      </span>
+                        {dayDate.getDate()}
+                      </div>
                     </div>
-                  )}
+                  )
+                })}
+              </div>
 
-                  {appointments.filter(a => a.day === colIdx).map(appt => {
-                    const c = COLOR_MAP[appt.color]
-                    return (
+              <div style={{ display: 'grid', gridTemplateColumns: '52px repeat(7, 1fr)', position: 'relative' }}>
+                {/* Hour labels */}
+                <div>
+                  {HOURS.map(h => (
+                    <div key={h} style={{ height: CELL_HEIGHT_PX, display: 'flex', alignItems: 'flex-start', justifyContent: 'flex-end', paddingRight: 8, paddingTop: 4 }}>
+                      <span style={{ fontSize: 10, color: 'var(--fg-3)', fontFamily: 'var(--font-mono, monospace)' }}>{h}:00</span>
+                    </div>
+                  ))}
+                </div>
+
+                {/* Day columns */}
+                {DAYS_ES.map((_, colIdx) => (
+                  <div key={colIdx} style={{ borderLeft: '1px solid var(--line)', position: 'relative', minHeight: CELL_HEIGHT_PX * HOURS.length }}>
+                    {HOURS.map(h => (
+                      <div key={h} style={{ height: CELL_HEIGHT_PX, borderTop: '1px solid var(--line)', opacity: 0.4, boxSizing: 'border-box' }} />
+                    ))}
+
+                    {weekOffset === 0 && colIdx === todayCols && (
                       <div
-                        key={appt.id}
-                        onClick={() => setSelectedAppt(appt)}
+                        ref={nowLineRef}
                         style={{
                           position: 'absolute',
-                          left: 3, right: 3,
-                          top: topPx(appt.startH, appt.startM),
-                          height: Math.max(heightPx(appt.durationMin), 24),
-                          background: c.bg,
-                          border: `1px solid ${c.border}`,
-                          borderRadius: 6,
-                          padding: '3px 6px',
-                          cursor: 'pointer',
-                          overflow: 'hidden',
-                          zIndex: 4,
+                          left: 0, right: 0,
+                          top: nowTop,
+                          height: 2,
+                          background: 'var(--led)',
+                          boxShadow: '0 0 0 1px rgba(255,255,255,0.55), 0 0 8px rgba(123,79,255,0.8)',
+                          zIndex: 5,
+                          pointerEvents: 'none',
                         }}
                       >
-                        <div style={{ fontSize: 10, fontWeight: 700, color: c.text, fontFamily: 'var(--font-ui)', lineHeight: 1.2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                          {appt.client}
-                        </div>
-                        {heightPx(appt.durationMin) > 30 && (
-                          <div style={{ fontSize: 9, color: 'var(--fg-2)', fontFamily: 'var(--font-ui)', lineHeight: 1.2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-                            {appt.service}
-                          </div>
-                        )}
+                        <span style={{
+                          position: 'absolute', left: 2, top: -18,
+                          fontSize: 9, fontFamily: 'var(--font-ui)', color: 'var(--led)',
+                          fontWeight: 600, letterSpacing: '0.04em', lineHeight: 1,
+                          pointerEvents: 'none', whiteSpace: 'nowrap',
+                        }}>
+                          {now.getHours().toString().padStart(2, '0')}:{now.getMinutes().toString().padStart(2, '0')}
+                        </span>
                       </div>
-                    )
-                  })}
-                </div>
-              ))}
+                    )}
+
+                    {appointments.filter(a => a.day === colIdx).map(appt => {
+                      const c = COLOR_MAP[appt.color]
+                      return (
+                        <div
+                          key={appt.id}
+                          onClick={() => setSelectedAppt(appt)}
+                          style={{
+                            position: 'absolute', left: 3, right: 3,
+                            top: topPx(appt.startH, appt.startM),
+                            height: Math.max(heightPx(appt.durationMin), 24),
+                            background: c.bg, border: `1px solid ${c.border}`,
+                            borderRadius: 6, padding: '3px 6px',
+                            cursor: 'pointer', overflow: 'hidden', zIndex: 4,
+                          }}
+                        >
+                          <div style={{ fontSize: 10, fontWeight: 700, color: c.text, fontFamily: 'var(--font-ui)', lineHeight: 1.2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                            {appt.client}
+                          </div>
+                          {heightPx(appt.durationMin) > 30 && (
+                            <div style={{ fontSize: 9, color: 'var(--fg-2)', fontFamily: 'var(--font-ui)', lineHeight: 1.2, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                              {appt.service}
+                            </div>
+                          )}
+                        </div>
+                      )
+                    })}
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-          </div>{/* end overflow-x */}
+            </div>
+          )}
         </div>
 
-        {/* Right column */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
+        {/* Right column — hidden in landscape to keep the grid in full view */}
+        {!isLandscape && <div style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}>
           {/* Upcoming today — first */}
           <div style={{ background: 'var(--bg-2)', border: '1px solid var(--line)', borderRadius: 12, padding: '1.25rem' }}>
             <div style={{ fontFamily: 'var(--font-display)', fontSize: 13, letterSpacing: '0.12em', color: 'var(--fg-3)', marginBottom: '0.875rem' }}>
@@ -502,7 +574,7 @@ export default function DashboardPage() {
               ))}
             </div>
           </div>
-        </div>
+        </div>}
       </div>
 
       {/* New appointment modal */}

--- a/src/pages/admin/SettingsPage.tsx
+++ b/src/pages/admin/SettingsPage.tsx
@@ -559,10 +559,10 @@ export default function SettingsPage() {
                         {d.open && (
                           <>
                             <input type="time" step="3600" value={d.from} onChange={e => handleTimeChange(key, 'from', e.target.value)}
-                              style={{ width: 64, background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.35rem 0.4rem', color: 'var(--fg-0)', fontFamily: 'var(--font-mono, monospace)', fontSize: 12 }} />
+                              style={{ width: 90, background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.35rem 0.4rem', color: 'var(--fg-0)', fontFamily: 'var(--font-mono, monospace)', fontSize: 12 }} />
                             <span style={{ color: 'var(--fg-3)', fontSize: 13 }}>–</span>
                             <input type="time" step="3600" value={d.to} onChange={e => handleTimeChange(key, 'to', e.target.value)}
-                              style={{ width: 64, background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.35rem 0.4rem', color: 'var(--fg-0)', fontFamily: 'var(--font-mono, monospace)', fontSize: 12 }} />
+                              style={{ width: 90, background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.35rem 0.4rem', color: 'var(--fg-0)', fontFamily: 'var(--font-mono, monospace)', fontSize: 12 }} />
                           </>
                         )}
                       </div>

--- a/src/pages/admin/SettingsPage.tsx
+++ b/src/pages/admin/SettingsPage.tsx
@@ -558,10 +558,10 @@ export default function SettingsPage() {
                         </button>
                         {d.open && (
                           <>
-                            <input value={d.from} onChange={e => handleTimeChange(key, 'from', e.target.value)}
+                            <input type="time" step="3600" value={d.from} onChange={e => handleTimeChange(key, 'from', e.target.value)}
                               style={{ width: 64, background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.35rem 0.4rem', color: 'var(--fg-0)', fontFamily: 'var(--font-mono, monospace)', fontSize: 12 }} />
                             <span style={{ color: 'var(--fg-3)', fontSize: 13 }}>–</span>
-                            <input value={d.to} onChange={e => handleTimeChange(key, 'to', e.target.value)}
+                            <input type="time" step="3600" value={d.to} onChange={e => handleTimeChange(key, 'to', e.target.value)}
                               style={{ width: 64, background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.35rem 0.4rem', color: 'var(--fg-0)', fontFamily: 'var(--font-mono, monospace)', fontSize: 12 }} />
                           </>
                         )}

--- a/src/pages/admin/SettingsPage.tsx
+++ b/src/pages/admin/SettingsPage.tsx
@@ -4,7 +4,8 @@ import { ConfirmDialog, Modal } from '@/components/ui'
 import { MonthCalendar } from '@/components/calendar'
 import { useAuth } from '@/hooks'
 import { useShopContext } from '@/context/ShopContext'
-import { useAllServices, useCreateService, useUpdateService, useDeleteService } from '@/hooks/useServices'
+import { useAllServices, useCreateService, useUpdateService, useDeleteService, useReactivateService, useSoftDeleteService } from '@/hooks/useServices'
+import { useAllAppointments } from '@/hooks/useAppointments'
 import { useAllBarbers, useUpdateBarber, useDeleteBarber, useAddBarberByEmail } from '@/hooks/useBarbers'
 import { useWeeklySchedule, useScheduleBlocks, useMutateWeeklySchedule, useAddScheduleBlock, useDeleteScheduleBlock } from '@/hooks/useSchedule'
 import { useShopInfo, useBookingConfig, useMutateShopInfo, useMutateBookingConfig } from '@/hooks/useShopConfig'
@@ -106,9 +107,12 @@ export default function SettingsPage() {
   const { data: rewardsData = [] } = useAllRewards()
 
   // ── Mutation hooks ──────────────────────────────────────────────────────────
+  const { data: allAppointments = [] } = useAllAppointments()
   const createService    = useCreateService()
   const updateService    = useUpdateService()
   const deleteService    = useDeleteService()
+  const reactivateService = useReactivateService()
+  const softDeleteService = useSoftDeleteService()
   const addBarberByEmail = useAddBarberByEmail()
   const updateBarber     = useUpdateBarber()
   const deleteBarber     = useDeleteBarber()
@@ -123,8 +127,12 @@ export default function SettingsPage() {
 
   // ── Services local state ────────────────────────────────────────────────────
   const [serviceEdits, setServiceEdits] = useState<Record<string, Partial<Service>>>({})
-  const services = servicesData.filter(svc => svc.isActive).map(svc => ({ ...svc, ...serviceEdits[svc.id] }))
+  const services = servicesData.map(svc => ({ ...svc, ...serviceEdits[svc.id] }))
   const [deleteServiceTarget, setDeleteServiceTarget] = useState<Service | null>(null)
+  const [softDeleteServiceTarget, setSoftDeleteServiceTarget] = useState<Service | null>(null)
+
+  const serviceHasActiveAppts = (serviceId: string) =>
+    allAppointments.some(a => a.serviceId === serviceId && a.status === 'confirmed')
 
   // ── Barbers local state ─────────────────────────────────────────────────────
   const [editingBarberId, setEditingBarberId] = useState<string | null>(null)
@@ -194,6 +202,15 @@ export default function SettingsPage() {
   const handleConfirmDeleteService = () => {
     if (!deleteServiceTarget) return
     deleteService.mutate(deleteServiceTarget.id, { onSuccess: () => setDeleteServiceTarget(null) })
+  }
+
+  const handleConfirmSoftDeleteService = () => {
+    if (!softDeleteServiceTarget) return
+    softDeleteService.mutate(softDeleteServiceTarget.id, { onSuccess: () => setSoftDeleteServiceTarget(null) })
+  }
+
+  const handleReactivateService = (id: string) => {
+    reactivateService.mutate(id)
   }
 
   // ── Handlers: barbers ───────────────────────────────────────────────────────
@@ -468,10 +485,15 @@ export default function SettingsPage() {
                   </thead>
                   <tbody>
                     {services.map(svc => (
-                      <tr key={svc.id} style={{ borderBottom: '1px solid var(--line)' }}>
+                      <tr key={svc.id} style={{ borderBottom: '1px solid var(--line)', opacity: svc.isActive ? 1 : 0.65 }}>
                         <td style={{ padding: '0.4rem 0.5rem' }}>
-                          <input value={svc.name} onChange={e => handleServiceFieldChange(svc.id, 'name', e.target.value)}
-                            style={{ background: 'var(--bg-3)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.3rem 0.5rem', color: 'var(--fg-0)', width: 160, fontFamily: 'var(--font-ui)', fontSize: 13 }} />
+                          <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+                            <input value={svc.name} onChange={e => handleServiceFieldChange(svc.id, 'name', e.target.value)}
+                              style={{ background: 'var(--bg-3)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.3rem 0.5rem', color: 'var(--fg-0)', width: 140, fontFamily: 'var(--font-ui)', fontSize: 13 }} />
+                            {!svc.isActive && (
+                              <span style={{ fontSize: 9, fontFamily: 'var(--font-ui)', letterSpacing: '0.08em', color: 'var(--fg-3)', background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 3, padding: '1px 5px' }}>INACTIVO</span>
+                            )}
+                          </div>
                         </td>
                         <td style={{ padding: '0.4rem 0.5rem' }}>
                           <input type="number" value={svc.durationMinutes} onChange={e => handleServiceFieldChange(svc.id, 'durationMinutes', Number(e.target.value))}
@@ -485,8 +507,22 @@ export default function SettingsPage() {
                           <input type="number" value={svc.loyaltyPoints} onChange={e => handleServiceFieldChange(svc.id, 'loyaltyPoints', Number(e.target.value))}
                             style={{ background: 'var(--bg-3)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.3rem 0.5rem', color: 'var(--fg-0)', width: 70, fontFamily: 'var(--font-ui)', fontSize: 13 }} />
                         </td>
-                        <td style={{ padding: '0.4rem 0.5rem' }}>
-                          <button onClick={() => setDeleteServiceTarget(svc)} style={{ background: 'transparent', border: 'none', color: 'var(--danger)', cursor: 'pointer', fontSize: 13 }}>Eliminar</button>
+                        <td style={{ padding: '0.4rem 0.5rem', whiteSpace: 'nowrap' }}>
+                          {svc.isActive ? (
+                            <button onClick={() => setDeleteServiceTarget(svc)} style={{ background: 'transparent', border: 'none', color: 'var(--fg-2)', cursor: 'pointer', fontSize: 12 }}>Desactivar</button>
+                          ) : (
+                            <>
+                              <button onClick={() => handleReactivateService(svc.id)} style={{ background: 'transparent', border: 'none', color: 'var(--led-soft)', cursor: 'pointer', fontSize: 12, marginRight: 6 }}>Reactivar</button>
+                              <button
+                                onClick={() => setSoftDeleteServiceTarget(svc)}
+                                disabled={serviceHasActiveAppts(svc.id)}
+                                title={serviceHasActiveAppts(svc.id) ? 'Hay citas activas con este servicio' : ''}
+                                style={{ background: 'transparent', border: 'none', color: serviceHasActiveAppts(svc.id) ? 'var(--fg-3)' : 'var(--danger)', cursor: serviceHasActiveAppts(svc.id) ? 'not-allowed' : 'pointer', fontSize: 12 }}
+                              >
+                                Eliminar
+                              </button>
+                            </>
+                          )}
                         </td>
                       </tr>
                     ))}
@@ -497,11 +533,32 @@ export default function SettingsPage() {
               {/* Mobile cards */}
               <div className="md:hidden flex flex-col gap-3">
                 {services.map(svc => (
-                  <div key={svc.id} style={{ background: 'var(--bg-3)', border: '1px solid var(--line)', borderRadius: 8, padding: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.625rem' }}>
+                  <div key={svc.id} style={{ background: 'var(--bg-3)', border: '1px solid var(--line)', borderRadius: 8, padding: '0.75rem', display: 'flex', flexDirection: 'column', gap: '0.625rem', opacity: svc.isActive ? 1 : 0.7 }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '0.5rem' }}>
-                      <input value={svc.name} onChange={e => handleServiceFieldChange(svc.id, 'name', e.target.value)}
-                        style={{ flex: 1, background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.35rem 0.5rem', color: 'var(--fg-0)', fontFamily: 'var(--font-ui)', fontSize: 14, fontWeight: 500 }} />
-                      <button onClick={() => setDeleteServiceTarget(svc)} style={{ background: 'transparent', border: 'none', color: 'var(--danger)', cursor: 'pointer', fontSize: 14, flexShrink: 0, padding: '0.25rem' }}>✕</button>
+                      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+                        <input value={svc.name} onChange={e => handleServiceFieldChange(svc.id, 'name', e.target.value)}
+                          style={{ width: '100%', background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 4, padding: '0.35rem 0.5rem', color: 'var(--fg-0)', fontFamily: 'var(--font-ui)', fontSize: 14, fontWeight: 500 }} />
+                        {!svc.isActive && (
+                          <span style={{ fontSize: 9, fontFamily: 'var(--font-ui)', letterSpacing: '0.08em', color: 'var(--fg-3)', background: 'var(--bg-4)', border: '1px solid var(--line)', borderRadius: 3, padding: '1px 5px', alignSelf: 'flex-start' }}>INACTIVO</span>
+                        )}
+                      </div>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', alignItems: 'flex-end', flexShrink: 0 }}>
+                        {svc.isActive ? (
+                          <button onClick={() => setDeleteServiceTarget(svc)} style={{ background: 'transparent', border: 'none', color: 'var(--fg-2)', cursor: 'pointer', fontSize: 11 }}>Desactivar</button>
+                        ) : (
+                          <>
+                            <button onClick={() => handleReactivateService(svc.id)} style={{ background: 'transparent', border: 'none', color: 'var(--led-soft)', cursor: 'pointer', fontSize: 11 }}>Reactivar</button>
+                            <button
+                              onClick={() => setSoftDeleteServiceTarget(svc)}
+                              disabled={serviceHasActiveAppts(svc.id)}
+                              title={serviceHasActiveAppts(svc.id) ? 'Hay citas activas con este servicio' : ''}
+                              style={{ background: 'transparent', border: 'none', color: serviceHasActiveAppts(svc.id) ? 'var(--fg-3)' : 'var(--danger)', cursor: serviceHasActiveAppts(svc.id) ? 'not-allowed' : 'pointer', fontSize: 11 }}
+                            >
+                              Eliminar
+                            </button>
+                          </>
+                        )}
+                      </div>
                     </div>
                     <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '0.5rem' }}>
                       {([
@@ -962,12 +1019,23 @@ export default function SettingsPage() {
 
       {deleteServiceTarget && (
         <ConfirmDialog
-          title="Eliminar servicio"
-          message={`¿Eliminar "${deleteServiceTarget.name}"? Esta acción no se puede deshacer.`}
-          confirmLabel="Eliminar"
+          title="Desactivar servicio"
+          message={`¿Desactivar "${deleteServiceTarget.name}"? Los clientes no podrán reservar este servicio. Las citas ya existentes no se verán afectadas.`}
+          confirmLabel="Desactivar"
           danger
           onConfirm={handleConfirmDeleteService}
           onCancel={() => setDeleteServiceTarget(null)}
+        />
+      )}
+
+      {softDeleteServiceTarget && (
+        <ConfirmDialog
+          title="Eliminar servicio"
+          message={`¿Eliminar permanentemente "${softDeleteServiceTarget.name}"? Desaparecerá de todas las vistas. Esta acción no se puede deshacer.`}
+          confirmLabel="Eliminar"
+          danger
+          onConfirm={handleConfirmSoftDeleteService}
+          onCancel={() => setSoftDeleteServiceTarget(null)}
         />
       )}
 

--- a/src/pages/client/CalendarPage.tsx
+++ b/src/pages/client/CalendarPage.tsx
@@ -11,7 +11,7 @@ import { useAuth } from '@/hooks'
 import { useServices } from '@/hooks/useServices'
 import { useBarbers } from '@/hooks/useBarbers'
 import { useWeeklySchedule, useScheduleBlocks } from '@/hooks/useSchedule'
-import { useClientAppointments, useCreateAppointment } from '@/hooks/useAppointments'
+import { useClientAppointments, useAllAppointments, useCreateAppointment } from '@/hooks/useAppointments'
 import type { Service } from '@/domain/service'
 import type { Barber } from '@/domain/barber'
 
@@ -45,6 +45,7 @@ export default function CalendarPage() {
   const { data: schedule = DEFAULT_WEEKLY_SCHEDULE, isLoading: loadingSchedule } = useWeeklySchedule()
   const { data: blocks = [] } = useScheduleBlocks()
   const { data: myAppointments = [] } = useClientAppointments(user?.id)
+  const { data: allAppointments = [] } = useAllAppointments()
   const createAppointment = useCreateAppointment()
 
   const [month, setMonth] = useState(today.getMonth())
@@ -55,6 +56,7 @@ export default function CalendarPage() {
   const [selectedBarber, setSelectedBarber] = useState<Barber | null>(null)
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [bookingError, setBookingError] = useState<string | null>(null)
+  const [bookingBlocked, setBookingBlocked] = useState(false)
 
   const { fromTime, toTime } = useMemo(() => {
     if (!selectedDate) return { fromTime: '10:00', toTime: '19:00' }
@@ -77,6 +79,62 @@ export default function CalendarPage() {
       getBarbersAvailableForSlot(slot, selectedService.durationMinutes, barbersToCheck).length === 0,
     )
   }, [selectedService, selectedBarber, availableBarbers, fromTime, toTime])
+
+  // Slots blocked because the barber(s) already have a confirmed appointment overlapping the slot
+  const appointmentBlockedSlots = useMemo<string[]>(() => {
+    if (!selectedDate || allAppointments.length === 0) return []
+    const barbersToCheck = selectedBarber
+      ? [selectedBarber.id]
+      : availableBarbers.map(b => b.id)
+    const dateStr = selectedDate.toISOString().slice(0, 10)
+    const dayAppts = allAppointments.filter(a =>
+      a.status === 'confirmed' &&
+      barbersToCheck.includes(a.barberId) &&
+      new Date(a.startTime).toISOString().slice(0, 10) === dateStr,
+    )
+    if (dayAppts.length === 0) return []
+    return generateScheduleSlots(fromTime, toTime).filter(slot => {
+      const [h, m] = slot.split(':').map(Number)
+      const slotStart = new Date(selectedDate)
+      slotStart.setHours(h, m, 0, 0)
+      const slotEnd = new Date(slotStart.getTime() + 30 * 60_000)
+      return dayAppts.some(a => new Date(a.startTime) < slotEnd && new Date(a.endTime) > slotStart)
+    })
+  }, [selectedDate, allAppointments, selectedBarber, availableBarbers, fromTime, toTime])
+
+  const takenSlots = useMemo<string[]>(
+    () => [...new Set([...breakBlockedSlots, ...appointmentBlockedSlots])],
+    [breakBlockedSlots, appointmentBlockedSlots],
+  )
+
+  // Services that can't be picked because their duration would overlap with an existing barber appointment
+  const unavailableServiceIds = useMemo<Set<string>>(() => {
+    if (!selectedDate || !selectedSlot || !selectedBarber) return new Set()
+    const [h, m] = selectedSlot.split(':').map(Number)
+    const slotStart = new Date(selectedDate)
+    slotStart.setHours(h, m, 0, 0)
+    const dateStr = selectedDate.toISOString().slice(0, 10)
+    const barberAppts = allAppointments.filter(a =>
+      a.status === 'confirmed' &&
+      a.barberId === selectedBarber.id &&
+      new Date(a.startTime).toISOString().slice(0, 10) === dateStr,
+    )
+    const ids = new Set<string>()
+    for (const service of services) {
+      const slotEnd = new Date(slotStart.getTime() + service.durationMinutes * 60_000)
+      const overlaps = barberAppts.some(a =>
+        new Date(a.startTime) < slotEnd && new Date(a.endTime) > slotStart,
+      )
+      if (overlaps) ids.add(service.id)
+    }
+    return ids
+  }, [selectedDate, selectedSlot, selectedBarber, allAppointments, services])
+
+  // True if client already has a future confirmed appointment
+  const hasActiveAppt = useMemo(() => {
+    const now = new Date()
+    return myAppointments.some(a => a.status === 'confirmed' && new Date(a.startTime) > now)
+  }, [myAppointments])
 
   const busyDays = useMemo<number[]>(() => {
     return myAppointments
@@ -114,6 +172,7 @@ export default function CalendarPage() {
     if (closedDayOfWeeks.includes(dayOfWeek)) return
     setSelectedDate(d)
     setSelectedSlot(null)
+    setBookingBlocked(hasActiveAppt)
     if (selectedBarber) {
       const stillAvailable = getAvailableBarbersForDate(d, schedule, blocks, allBarbers)
         .some(b => b.id === selectedBarber.id)
@@ -193,16 +252,36 @@ export default function CalendarPage() {
           )}
           {selectedDate && availableBarbers.length > 0 && (
             <div className={CARD}>
-              <div className={SECTION_LABEL}>
-                HORA — {fmt(selectedDate).toUpperCase()}
-              </div>
-              <TimeSlots
-                selected={selectedSlot}
-                onSelect={setSelectedSlot}
-                taken={breakBlockedSlots}
-                fromTime={fromTime}
-                toTime={toTime}
-              />
+              {bookingBlocked ? (
+                <div style={{ padding: '0.25rem 0' }}>
+                  <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--fg-0)', fontFamily: 'var(--font-ui)', marginBottom: 6 }}>
+                    Ya tienes una cita reservada
+                  </div>
+                  <div style={{ fontSize: 13, color: 'var(--fg-2)', fontFamily: 'var(--font-ui)', lineHeight: 1.6 }}>
+                    Para cambiar el horario, reprograma tu cita desde{' '}
+                    <button
+                      onClick={() => navigate('/appointments')}
+                      style={{ background: 'none', border: 'none', padding: 0, color: 'var(--led-soft)', cursor: 'pointer', fontFamily: 'var(--font-ui)', fontSize: 13 }}
+                    >
+                      Mis Citas
+                    </button>
+                    .
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <div className={SECTION_LABEL}>
+                    HORA — {fmt(selectedDate).toUpperCase()}
+                  </div>
+                  <TimeSlots
+                    selected={selectedSlot}
+                    onSelect={setSelectedSlot}
+                    taken={takenSlots}
+                    fromTime={fromTime}
+                    toTime={toTime}
+                  />
+                </>
+              )}
             </div>
           )}
 
@@ -280,6 +359,7 @@ export default function CalendarPage() {
                     service={s}
                     selected={selectedService?.id === s.id}
                     onClick={() => setSelectedService(s)}
+                    disabled={unavailableServiceIds.has(s.id)}
                   />
                 ))}
               </div>

--- a/src/pages/client/CalendarPage.tsx
+++ b/src/pages/client/CalendarPage.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '@/hooks'
 import { useServices } from '@/hooks/useServices'
 import { useBarbers } from '@/hooks/useBarbers'
 import { useWeeklySchedule, useScheduleBlocks } from '@/hooks/useSchedule'
-import { useCreateAppointment } from '@/hooks/useAppointments'
+import { useClientAppointments, useCreateAppointment } from '@/hooks/useAppointments'
 import type { Service } from '@/domain/service'
 import type { Barber } from '@/domain/barber'
 
@@ -53,6 +53,7 @@ export default function CalendarPage() {
   const { data: allBarbers = [] } = useBarbers()
   const { data: schedule = DEFAULT_WEEKLY_SCHEDULE, isLoading: loadingSchedule } = useWeeklySchedule()
   const { data: blocks = [] } = useScheduleBlocks()
+  const { data: myAppointments = [] } = useClientAppointments(user?.id)
   const createAppointment = useCreateAppointment()
 
   const [month, setMonth] = useState(today.getMonth())
@@ -78,6 +79,16 @@ export default function CalendarPage() {
       getBarbersAvailableForSlot(slot, selectedService.durationMinutes, barbersToCheck).length === 0,
     )
   }, [selectedService, selectedBarber, availableBarbers])
+
+  const busyDays = useMemo<number[]>(() => {
+    return myAppointments
+      .filter(a => a.status !== 'cancelled' && a.status !== 'no_show')
+      .filter(a => {
+        const d = new Date(a.startTime)
+        return d.getFullYear() === year && d.getMonth() === month
+      })
+      .map(a => new Date(a.startTime).getDate())
+  }, [myAppointments, year, month])
 
   // Day-of-week numbers (0=Mon … 6=Sun ISO) that are fully closed per the weekly schedule
   const closedDayOfWeeks = useMemo<number[]>(() => {
@@ -170,6 +181,7 @@ export default function CalendarPage() {
               maxDate={maxDate}
               closedDayOfWeeks={closedDayOfWeeks}
               partialDates={partialDates}
+              busyDays={busyDays}
             />
           </div>
 

--- a/src/pages/client/CalendarPage.tsx
+++ b/src/pages/client/CalendarPage.tsx
@@ -4,8 +4,7 @@ import { Helmet } from 'react-helmet-async'
 import { useShopContext } from '@/context/ShopContext'
 import { getMaxBookingDate, getAvailableBarbersForDate, getBarbersAvailableForSlot } from '@/domain/booking'
 import { DEFAULT_WEEKLY_SCHEDULE, type DayKey } from '@/domain/schedule'
-import { MonthCalendar } from '@/components/calendar'
-import { TimeSlots } from '@/components/calendar'
+import { MonthCalendar, TimeSlots, generateScheduleSlots } from '@/components/calendar'
 import { ServiceCard } from '@/components/appointments'
 import { Modal } from '@/components/ui'
 import { useAuth } from '@/hooks'
@@ -32,15 +31,7 @@ function getInitials(fullName: string): string {
 const CARD = 'bg-[var(--bg-2)] border border-[var(--line)] rounded-xl p-4 md:p-5'
 const SECTION_LABEL = 'font-[var(--font-display)] text-[13px] tracking-widest text-[var(--fg-3)] mb-3.5'
 
-// Must match the slots generated in TimeSlots component (10:00–19:00)
-const BOOKING_SLOTS: string[] = (() => {
-  const slots: string[] = []
-  for (let h = 10; h <= 19; h++) {
-    slots.push(`${String(h).padStart(2, '0')}:00`)
-    if (h < 19) slots.push(`${String(h).padStart(2, '0')}:30`)
-  }
-  return slots
-})()
+const JS_TO_DAY: Record<number, DayKey> = { 1: 'mon', 2: 'tue', 3: 'wed', 4: 'thu', 5: 'fri', 6: 'sat', 0: 'sun' }
 
 export default function CalendarPage() {
   const navigate = useNavigate()
@@ -65,6 +56,13 @@ export default function CalendarPage() {
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [bookingError, setBookingError] = useState<string | null>(null)
 
+  const { fromTime, toTime } = useMemo(() => {
+    if (!selectedDate) return { fromTime: '10:00', toTime: '19:00' }
+    const key = JS_TO_DAY[selectedDate.getDay()]
+    const day = schedule[key]
+    return { fromTime: day.from || '10:00', toTime: day.to || '19:00' }
+  }, [selectedDate, schedule])
+
   // While schedule is loading, show all active barbers unfiltered to avoid empty flicker
   const availableBarbers = useMemo<Barber[]>(() => {
     if (loadingSchedule || !selectedDate) return allBarbers.filter(b => b.isActive)
@@ -75,10 +73,10 @@ export default function CalendarPage() {
   const breakBlockedSlots = useMemo<string[]>(() => {
     if (!selectedService) return []
     const barbersToCheck = selectedBarber ? [selectedBarber] : availableBarbers
-    return BOOKING_SLOTS.filter(slot =>
+    return generateScheduleSlots(fromTime, toTime).filter(slot =>
       getBarbersAvailableForSlot(slot, selectedService.durationMinutes, barbersToCheck).length === 0,
     )
-  }, [selectedService, selectedBarber, availableBarbers])
+  }, [selectedService, selectedBarber, availableBarbers, fromTime, toTime])
 
   const busyDays = useMemo<number[]>(() => {
     return myAppointments
@@ -202,6 +200,8 @@ export default function CalendarPage() {
                 selected={selectedSlot}
                 onSelect={setSelectedSlot}
                 taken={breakBlockedSlots}
+                fromTime={fromTime}
+                toTime={toTime}
               />
             </div>
           )}

--- a/src/pages/super-admin/AdminPanelPage.tsx
+++ b/src/pages/super-admin/AdminPanelPage.tsx
@@ -1,8 +1,10 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { useAuth } from '@/hooks'
 import { useAdminProfiles, useUpdateProfileRole } from '@/hooks/useProfile'
 import type { UserRole } from '@/domain/user'
+
+const PAGE_SIZE = 10
 
 const ROLE_LABELS: Record<UserRole, string> = {
   admin: 'Administrador',
@@ -22,20 +24,66 @@ const SECTION_TITLE = {
 } as const
 
 type PendingRole = { from: UserRole; to: UserRole }
+type SortKey = 'name' | 'email' | 'role'
+type SortDir = 'asc' | 'desc'
 
 export default function AdminPanelPage() {
   const { user } = useAuth()
   const [search, setSearch] = useState('')
+  const [roleFilter, setRoleFilter] = useState<UserRole | 'all'>('all')
+  const [sortKey, setSortKey] = useState<SortKey>('name')
+  const [sortDir, setSortDir] = useState<SortDir>('asc')
+  const [page, setPage] = useState(0)
   const [pendingRoles, setPendingRoles] = useState<Record<string, PendingRole>>({})
   const [saveError, setSaveError] = useState<string | null>(null)
 
   const { data: profiles = [], isLoading, error: loadError } = useAdminProfiles()
   const updateRole = useUpdateProfileRole()
 
-  const filtered = profiles.filter(p =>
-    p.email.toLowerCase().includes(search.toLowerCase()) ||
-    (p.fullName ?? '').toLowerCase().includes(search.toLowerCase()),
-  )
+  const processed = useMemo(() => {
+    let result = profiles.filter(p => {
+      const matchSearch =
+        p.email.toLowerCase().includes(search.toLowerCase()) ||
+        (p.fullName ?? '').toLowerCase().includes(search.toLowerCase())
+      const matchRole = roleFilter === 'all' || p.role === roleFilter
+      return matchSearch && matchRole
+    })
+
+    result = [...result].sort((a, b) => {
+      const va = sortKey === 'name' ? (a.fullName ?? a.email).toLowerCase()
+        : sortKey === 'email' ? a.email.toLowerCase()
+        : a.role
+      const vb = sortKey === 'name' ? (b.fullName ?? b.email).toLowerCase()
+        : sortKey === 'email' ? b.email.toLowerCase()
+        : b.role
+      return sortDir === 'asc' ? va.localeCompare(vb) : vb.localeCompare(va)
+    })
+
+    return result
+  }, [profiles, search, roleFilter, sortKey, sortDir])
+
+  const totalPages = Math.max(1, Math.ceil(processed.length / PAGE_SIZE))
+  const paginated = processed.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+
+  function handleFilterChange(newFilter: UserRole | 'all') {
+    setRoleFilter(newFilter)
+    setPage(0)
+  }
+
+  function handleSearchChange(value: string) {
+    setSearch(value)
+    setPage(0)
+  }
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir('asc')
+    }
+    setPage(0)
+  }
 
   function handleRoleChange(id: string, currentRole: UserRole, newRole: UserRole) {
     if (currentRole === 'admin') return
@@ -68,6 +116,11 @@ export default function AdminPanelPage() {
 
   const hasPending = Object.keys(pendingRoles).length > 0
 
+  const sortIndicator = (key: SortKey) => {
+    if (sortKey !== key) return null
+    return <span style={{ marginLeft: 3, fontSize: 9 }}>{sortDir === 'asc' ? '▲' : '▼'}</span>
+  }
+
   return (
     <>
       <Helmet><title>Panel Admin · Gio Barber Shop</title></Helmet>
@@ -86,19 +139,61 @@ export default function AdminPanelPage() {
 
         <div style={SECTION_TITLE}>USUARIOS REGISTRADOS</div>
 
-        <input
-          type="search"
-          placeholder="Buscar por email o nombre…"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          style={{
-            width: '100%', boxSizing: 'border-box',
-            background: 'var(--bg-3)', border: '1px solid var(--line)',
-            borderRadius: 8, padding: '0.6rem 0.75rem',
-            color: 'var(--fg-0)', fontFamily: 'var(--font-ui)', fontSize: 13,
-            outline: 'none', marginBottom: '1rem',
-          }}
-        />
+        {/* Search + role filter */}
+        <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.75rem', flexWrap: 'wrap' }}>
+          <input
+            type="search"
+            placeholder="Buscar por email o nombre…"
+            value={search}
+            onChange={e => handleSearchChange(e.target.value)}
+            style={{
+              flex: 1, minWidth: 180, boxSizing: 'border-box',
+              background: 'var(--bg-3)', border: '1px solid var(--line)',
+              borderRadius: 8, padding: '0.6rem 0.75rem',
+              color: 'var(--fg-0)', fontFamily: 'var(--font-ui)', fontSize: 13,
+              outline: 'none',
+            }}
+          />
+          <select
+            value={roleFilter}
+            onChange={e => handleFilterChange(e.target.value as UserRole | 'all')}
+            style={{
+              background: 'var(--bg-3)', border: '1px solid var(--line)',
+              borderRadius: 8, padding: '0.6rem 0.75rem',
+              color: 'var(--fg-0)', fontFamily: 'var(--font-ui)', fontSize: 13,
+              outline: 'none', cursor: 'pointer',
+            }}
+          >
+            <option value="all">Todos los roles</option>
+            {ALL_ROLES.map(r => (
+              <option key={r} value={r}>{ROLE_LABELS[r]}</option>
+            ))}
+          </select>
+        </div>
+
+        {/* Sort controls */}
+        <div style={{ display: 'flex', gap: '0.4rem', marginBottom: '1rem', alignItems: 'center' }}>
+          <span style={{ fontSize: 11, color: 'var(--fg-3)', fontFamily: 'var(--font-ui)', marginRight: 4 }}>Ordenar:</span>
+          {(['name', 'email', 'role'] as SortKey[]).map(key => (
+            <button
+              key={key}
+              onClick={() => handleSort(key)}
+              style={{
+                padding: '0.3rem 0.65rem', borderRadius: 6, fontSize: 11,
+                fontFamily: 'var(--font-ui)', cursor: 'pointer',
+                background: sortKey === key ? 'var(--bg-4)' : 'var(--bg-3)',
+                border: `1px solid ${sortKey === key ? 'var(--led-soft)' : 'var(--line)'}`,
+                color: sortKey === key ? 'var(--fg-0)' : 'var(--fg-2)',
+              }}
+            >
+              {key === 'name' ? 'Nombre' : key === 'email' ? 'Email' : 'Rol'}
+              {sortIndicator(key)}
+            </button>
+          ))}
+          <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--fg-3)', fontFamily: 'var(--font-ui)' }}>
+            {processed.length} usuario{processed.length !== 1 ? 's' : ''}
+          </span>
+        </div>
 
         {isLoading && (
           <div style={{ color: 'var(--fg-2)', fontSize: 13, fontFamily: 'var(--font-ui)', padding: '1rem 0' }}>
@@ -112,14 +207,14 @@ export default function AdminPanelPage() {
           </div>
         )}
 
-        {!isLoading && !loadError && filtered.length === 0 && (
+        {!isLoading && !loadError && processed.length === 0 && (
           <div style={{ color: 'var(--fg-2)', fontSize: 13, fontFamily: 'var(--font-ui)', padding: '1rem 0' }}>
             No se encontraron usuarios.
           </div>
         )}
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-          {filtered.map(profile => {
+          {paginated.map(profile => {
             const isAdminRole = profile.role === 'admin'
             const isSelf = profile.id === user?.id
             const displayRole = pendingRoles[profile.id]?.to ?? profile.role
@@ -189,6 +284,41 @@ export default function AdminPanelPage() {
             )
           })}
         </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '0.75rem', marginTop: '1rem' }}>
+            <button
+              onClick={() => setPage(p => Math.max(0, p - 1))}
+              disabled={page === 0}
+              style={{
+                padding: '0.4rem 0.9rem', borderRadius: 7, fontSize: 12,
+                fontFamily: 'var(--font-ui)', cursor: page === 0 ? 'default' : 'pointer',
+                background: 'var(--bg-3)', border: '1px solid var(--line)',
+                color: page === 0 ? 'var(--fg-3)' : 'var(--fg-1)',
+                opacity: page === 0 ? 0.5 : 1,
+              }}
+            >
+              ← Anterior
+            </button>
+            <span style={{ fontSize: 12, color: 'var(--fg-2)', fontFamily: 'var(--font-ui)' }}>
+              {page + 1} / {totalPages}
+            </span>
+            <button
+              onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+              disabled={page === totalPages - 1}
+              style={{
+                padding: '0.4rem 0.9rem', borderRadius: 7, fontSize: 12,
+                fontFamily: 'var(--font-ui)', cursor: page === totalPages - 1 ? 'default' : 'pointer',
+                background: 'var(--bg-3)', border: '1px solid var(--line)',
+                color: page === totalPages - 1 ? 'var(--fg-3)' : 'var(--fg-1)',
+                opacity: page === totalPages - 1 ? 0.5 : 1,
+              }}
+            >
+              Siguiente →
+            </button>
+          </div>
+        )}
 
         {/* Confirmation panel */}
         {hasPending && (

--- a/src/pages/super-admin/AdminPanelPage.tsx
+++ b/src/pages/super-admin/AdminPanelPage.tsx
@@ -31,7 +31,7 @@ export default function AdminPanelPage() {
   const { user } = useAuth()
   const [search, setSearch] = useState('')
   const [roleFilter, setRoleFilter] = useState<UserRole | 'all'>('all')
-  const [sortKey, setSortKey] = useState<SortKey>('name')
+  const [sortKey, setSortKey] = useState<SortKey>('role')
   const [sortDir, setSortDir] = useState<SortDir>('asc')
   const [page, setPage] = useState(0)
   const [pendingRoles, setPendingRoles] = useState<Record<string, PendingRole>>({})
@@ -86,7 +86,7 @@ export default function AdminPanelPage() {
   }
 
   function handleRoleChange(id: string, currentRole: UserRole, newRole: UserRole) {
-    if (currentRole === 'admin') return
+    if (currentRole === 'admin' || newRole === 'admin') return
     setPendingRoles(prev => {
       const original = prev[id]?.from ?? currentRole
       if (original === newRole) {
@@ -274,7 +274,7 @@ export default function AdminPanelPage() {
                         cursor: 'pointer', outline: 'none',
                       }}
                     >
-                      {ALL_ROLES.map(r => (
+                      {ALL_ROLES.filter(r => r !== 'admin').map(r => (
                         <option key={r} value={r}>{ROLE_LABELS[r]}</option>
                       ))}
                     </select>


### PR DESCRIPTION
## Resumen

Resolución de los issues #70 y #72. Incluye correcciones de UI en el calendario de clientes, mejoras en el panel de administración y la agenda del admin.

## Cambios incluidos

### Calendario de clientes
- **Fix width inputs horario**: los campos de hora ya muestran el valor completo (90px en lugar de 64px)
- **Bloqueo de slots ocupados**: los horarios con citas confirmadas del barbero seleccionado aparecen desactivados y no se pueden seleccionar
- **Bloqueo de reserva si ya tienes cita activa**: al pulsar un día, si el cliente ya tiene una cita confirmada futura, se muestra un mensaje explicativo en lugar de los horarios disponibles
- **Servicios no disponibles por solapamiento**: si la duración de un servicio se solaparía con otra cita del barbero, la tarjeta del servicio aparece desactivada con badge "NO DISPONIBLE"
- **Dot de día ocupado más visible**: en el calendario mensual, el indicador de día con cita pasa de 4px gris a 6px con color `--led`

### Dashboard admin
- **Nombres de clientes en la agenda**: corrección del JOIN de `profiles` — se mostraba el UUID en lugar del nombre
- **Vista landscape en móvil**: en horizontal, la agenda muestra solo Hoy y Mañana, con las horas en el eje X (columnas) y los días en el eje Y (filas)

### Panel de administración
- **Paginación**: 10 usuarios por página con controles de navegación
- **Filtros y ordenación**: filtro por rol + ordenación por nombre, email o rol
- **Bloqueo asignación rol admin**: el select de rol no muestra la opción "Administrador" y el handler rechaza `newRole === 'admin'`

### Servicios (SettingsPage)
- **Dos estados independientes**: `is_active` (desactivado — admin ve el servicio, clientes no pueden reservar; las citas existentes se completan) e `is_deleted` (soft-delete — oculto en todo, solo aplicable cuando no hay citas activas del servicio)
- **UI de gestión**: badge INACTIVO, botón Reactivar y botón Eliminar (deshabilitado si hay citas activas)

## Test plan

- [ ] Abrir CalendarPage → seleccionar barbero y fecha → verificar slots ocupados bloqueados
- [ ] Tener una cita confirmada futura → intentar reservar otro día → ver mensaje de bloqueo
- [ ] Seleccionar un slot válido → ver servicios con duración que solapa marcados como NO DISPONIBLE
- [ ] Dashboard en DevTools con emulación landscape 667×375 → ver vista 2 días con horas en X
- [ ] AdminPanel → ver paginación, filtro de rol, sort → el select de rol no muestra "Administrador"
- [ ] SettingsPage → desactivar un servicio → aparece INACTIVO; reactivar → vuelve activo; eliminar solo habilitado si sin citas

🤖 Generated with [Claude Code](https://claude.com/claude-code)