### PR TITLE
feat(admin): color theme selector with palette picker and live preview

### DIFF
--- a/.claude/CONSTITUTION.md
+++ b/.claude/CONSTITUTION.md
@@ -68,6 +68,7 @@ domain/ no importa NADA externo
 5. Los servicios tienen duración fija que determina los slots disponibles.
 6. Sesión **cliente**: persistente indefinida.
 7. Sesión **admin**: máximo **15 días** desde el login (`ADMIN_SESSION_MAX_DAYS = 15`). Forzar logout si supera. Timestamp en localStorage (`admin_login_time`).
+8. Los servicios tienen **dos estados independientes**: `is_active` (desactivar: nadie puede pedir cita nueva, las existentes se completan) e `is_deleted` (soft-delete: oculto en todo — solo aplicable cuando el servicio ya no tiene citas activas). El admin puede desactivar/reactivar libremente; solo puede eliminar si `serviceHasActiveAppts === false`.
 
 ---
 
@@ -76,12 +77,14 @@ domain/ no importa NADA externo
 ```
 barbers           id, full_name, role, bio, avatar_url, phone, email, specialty_ids(JSONB), is_active
 profiles          id→auth.users, full_name, phone, avatar_url, role('client'|'admin')
-services          id, name, description, duration_minutes, price, loyalty_points, is_active, sort_order
+services          id, name, description, duration_minutes, price, loyalty_points, is_active, is_deleted, sort_order
+                  is_active=false → desactivado (admin ve; clientes no pueden reservar; citas activas se completan)
+                  is_deleted=true → soft-delete (oculto en todo; solo aplicar cuando no hay citas activas del servicio)
 appointments      id, client_id→profiles, barber_id→barbers, service_id→services, start_time, end_time, status, notes
                   status: 'confirmed' | 'completed' | 'cancelled' | 'no_show'
 schedule_blocks   id, barber_id→barbers (NULL=todos), block_date, start_time, end_time, day_of_week, reason, is_recurring
 shop_config       id, key (unique), value(JSONB)
-                  keys: shop_info, schedule, booking, loyalty
+                  keys: shop_info, schedule, booking, loyalty, color_theme
 loyalty_cards     id, client_id→profiles (unique), total_points, total_visits
 loyalty_transactions  id, card_id→loyalty_cards, appointment_id→appointments, points, type, description
                   type: 'earned' | 'redeemed' | 'bonus' | 'adjustment'

--- a/.claude/CONSTITUTION.md
+++ b/.claude/CONSTITUTION.md
@@ -2,7 +2,7 @@
 
 > **Este documento es la fuente de verdad inmutable.** Ningún agente debe modificarlo sin permiso explícito del usuario. Si detecta que algo ha cambiado en la realidad del código y el Constitution debería actualizarse, **avisa primero**, explica QUÉ cambia, QUÉ quedará y POR QUÉ, y espera confirmación.
 
-Versión: 1.1.0 · Última revisión: 2026-04-17
+Versión: 1.2.0 · Última revisión: 2026-05-04
 
 ---
 
@@ -208,23 +208,34 @@ Formato: `type(scope): descripción en inglés, presente imperativo`.
 
 ---
 
-## Art. 10 — Paleta de colores (no cambiar sin consenso)
+## Art. 10 — Tokens de color (CSS vars — defaults no cambiar sin consenso)
 
-| Token             | Valor     | Uso                                          |
-| ----------------- | --------- | -------------------------------------------- |
-| Primario (Dorado) | `#C8A44E` | Acentos, botones principales, iconos activos |
-| Hover dorado      | `#b8943e` | Hover botones dorados                        |
-| Fondo oscuro      | `#1A1A1A` | Tema oscuro                                  |
-| Fondo claro       | `#FAFAFA` | Tema claro                                   |
-| Texto primario    | `#111111` |                                              |
-| Texto secundario  | `#6B7280` |                                              |
-| Borde             | `#E5E7EB` |                                              |
-| Éxito             | `#10B981` | Cita confirmada                              |
-| Error             | `#EF4444` | Cancelación, errores                         |
-| Warning           | `#F59E0B` | Avisos                                       |
-| Superficie card   | `#FFFFFF` |                                              |
+Los colores se definen como CSS custom properties en `src/styles/globals.css`.
+Los 5 tokens de acento son configurables por el admin desde **Apariencia → SettingsPage** y se persisten en `shop_config → color_theme`. Se aplican sobreescribiendo las vars via `<style id="gio-palette-style">` inyectado antes de `createRoot`.
 
-**Tipografía**: Inter (Google Fonts), `font-display: swap`, preconnect en `<head>`.
+### Tokens de acento (configurables por admin)
+
+| CSS Var         | Default dark | Default light | Uso                                |
+| --------------- | ------------ | ------------- | ---------------------------------- |
+| `--led`         | `#7b4fff`    | `#6235e0`     | Acento principal, botones activos  |
+| `--led-soft`    | `#a689ff`    | `#7b4fff`     | Hover, variante suave del acento   |
+| `--gold`        | `#c9a24a`    | `#a88030`     | Tono cálido, CTAs secundarios      |
+| `--brick`       | `#8b3a1f`    | `#9a4010`     | Acento secundario                  |
+| `--brick-warm`  | `#c06a3d`    | `#c06030`     | Variante cálida de brick           |
+| `--card-accent` | `var(--gold)` | `var(--gold)` | Acento LoyaltyCard (contexto dark) |
+
+### Tokens de estado y semánticos (no configurables)
+
+| CSS Var     | Uso              |
+| ----------- | ---------------- |
+| `--danger`  | Error, cancelación (`#c04040` dark / `#c03030` light) |
+| `--ok`      | Éxito, confirmado (`#6dbb6d`) |
+
+### Tipografía
+
+Inter (Google Fonts), `font-display: swap`, preconnect en `<head>`.
+
+**Los defaults en `globals.css` y las paletas predefinidas en `src/domain/colorTheme/index.ts` no se cambian sin consenso.**
 
 ---
 

--- a/.claude/KNOWLEDGE.md
+++ b/.claude/KNOWLEDGE.md
@@ -8,6 +8,16 @@ Cada entrada debe tener: **Fecha · Contexto · Qué · Por qué importa**.
 
 ## InsForge — SDK, API y documentación
 
+### 2026-05-04 · InsForge · Join embebido devuelve profiles como array, no como objeto
+
+**Qué**: Al hacer `.select('..., profiles(full_name)')` en InsForge (embedded join), el SDK infiere un tipo para `profiles` que no es directamente asignable a `{ full_name: string | null } | null`. TypeScript fuerza el doble cast `as unknown as RowType[]` si el tipo local no coincide.
+
+**Fix**: definir una interfaz intermedia `AppointmentRowRaw` con `profiles: Array<{ full_name: string | null }> | { full_name: string | null } | null` y normalizar con `profiles?.[0] ?? null` antes de pasar al mapper. Así se elimina el `unknown` cast.
+
+**Regla**: al añadir un join embebido en cualquier query InsForge, crear un tipo `*Raw` para el resultado del SDK y un `normalizeRow()` que lo convierte al tipo de dominio. Ver `src/infrastructure/insforge/appointmentRepository.ts → AppointmentRowRaw`.
+
+
+
 ### 2026-04-19 · InsForge SDK · NO usar @supabase/supabase-js — tiene su propio SDK
 
 **Qué**: InsForge NO es Supabase. Aunque comparte conceptos similares (PostgreSQL, Auth, Storage), usa su **propio SDK** con rutas de API completamente diferentes. Usar `@supabase/supabase-js` con URLs de InsForge da 404 en todos los endpoints de auth.
@@ -125,6 +135,26 @@ is_project_admin (boolean), is_anonymous (boolean)
 **Si las herramientas no aparecen**: los MCPs se cargan solo al inicio de sesión. Si se modificó `~/.claude/settings.json` durante la sesión, hay que reiniciar Claude Code para que tome efecto.
 
 **Para añadir un nuevo proyecto InsForge**: editar `~/.claude/settings.json` directamente — ver Art. 13 para el formato exacto.
+
+## InsForge — JOIN de tablas relacionadas
+
+### 2026-05-04 · InsForge SDK · JOIN syntax — usar nombre de tabla, no nombre del FK
+
+**Qué**: InsForge PostgREST usa la sintaxis `tabla_relacionada(columna)` en el SELECT para hacer JOINs. La sintaxis con nombre explícito de FK (`tabla!fk_name(col)`) puede fallar si el nombre real del FK en InsForge difiere del esperado.
+
+**Regla**: SIEMPRE usar `profiles(full_name)` (nombre de tabla), NUNCA `profiles!appointments_client_id_fkey(full_name)` (nombre de FK).
+
+```typescript
+// ✅ Correcto
+const SELECT = 'id, start_time, profiles(full_name)'
+
+// ❌ Rompe si el FK tiene nombre diferente en InsForge
+const SELECT = 'id, start_time, profiles!appointments_client_id_fkey(full_name)'
+```
+
+**Síntoma de error**: el campo `profiles` llega como `null` o el query falla silenciosamente.
+
+---
 
 ## Gotchas del stack
 

--- a/src/components/appearance/AppearanceSection.tsx
+++ b/src/components/appearance/AppearanceSection.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react'
+import type { ColorThemeConfig, CustomPalette } from '@/domain/colorTheme'
+import { getPaletteById } from '@/domain/colorTheme'
+import { useColorTheme, useMutateColorTheme } from '@/hooks/useColorTheme'
+import { PalettePicker } from './PalettePicker'
+import { ThemePreview } from './ThemePreview'
+import { CustomPaletteEditor } from './CustomPaletteEditor'
+
+type EditorState =
+  | { open: false }
+  | { open: true; mode: 'dark' | 'light'; editing?: CustomPalette }
+
+export function AppearanceSection() {
+  const { data: savedConfig, isLoading } = useColorTheme()
+  const { mutate: saveTheme, isPending: isSaving } = useMutateColorTheme()
+
+  const [pendingDarkId, setPendingDarkId] = useState<string | null>(null)
+  const [pendingLightId, setPendingLightId] = useState<string | null>(null)
+  const [pendingCustom, setPendingCustom] = useState<CustomPalette[]>([])
+  const [editor, setEditor] = useState<EditorState>({ open: false })
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const activeDarkId = pendingDarkId ?? savedConfig?.activeDarkPaletteId ?? null
+  const activeLightId = pendingLightId ?? savedConfig?.activeLightPaletteId ?? null
+  const customs = pendingCustom.length > 0 ? pendingCustom : (savedConfig?.customPalettes ?? [])
+
+  const darkTokens = activeDarkId ? getPaletteById(activeDarkId, customs)?.tokens ?? null : null
+  const lightTokens = activeLightId ? getPaletteById(activeLightId, customs)?.tokens ?? null : null
+
+  const isDirty =
+    activeDarkId !== (savedConfig?.activeDarkPaletteId ?? null) ||
+    activeLightId !== (savedConfig?.activeLightPaletteId ?? null) ||
+    pendingCustom.length > 0
+
+  function handleSaveCustom(palette: CustomPalette) {
+    setPendingCustom((prev) => {
+      const existing = prev.findIndex((p) => p.id === palette.id)
+      if (existing >= 0) {
+        const next = [...prev]
+        next[existing] = palette
+        return next
+      }
+      return [...prev, palette]
+    })
+    setEditor({ open: false })
+    if (palette.mode === 'dark') setPendingDarkId(palette.id)
+    else setPendingLightId(palette.id)
+  }
+
+  function handleConfirmSave() {
+    const config: ColorThemeConfig = {
+      activeDarkPaletteId: activeDarkId,
+      activeLightPaletteId: activeLightId,
+      customPalettes: customs,
+    }
+    saveTheme(config, {
+      onSuccess: () => {
+        setPendingDarkId(null)
+        setPendingLightId(null)
+        setPendingCustom([])
+        setConfirmOpen(false)
+      },
+    })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16" style={{ color: 'var(--fg-3)' }}>
+        Cargando...
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Preview */}
+      <div>
+        <h2
+          className="text-[11px] font-bold tracking-[0.2em] uppercase mb-4"
+          style={{ color: 'var(--fg-3)' }}
+        >
+          Vista previa
+        </h2>
+        <ThemePreview darkTokens={darkTokens} lightTokens={lightTokens} />
+      </div>
+
+      {/* Picker */}
+      <div>
+        <h2
+          className="text-[11px] font-bold tracking-[0.2em] uppercase mb-4"
+          style={{ color: 'var(--fg-3)' }}
+        >
+          Paletas
+        </h2>
+        <PalettePicker
+          selectedDarkId={activeDarkId}
+          selectedLightId={activeLightId}
+          customPalettes={customs}
+          onSelectDark={(id) => setPendingDarkId(id)}
+          onSelectLight={(id) => setPendingLightId(id)}
+          onEditCustom={(p) => setEditor({ open: true, mode: p.mode, editing: p })}
+        />
+      </div>
+
+      {/* Custom palette editor toggle */}
+      {!editor.open && (
+        <div className="flex gap-3">
+          <button
+            type="button"
+            className="btn ghost text-sm"
+            onClick={() => setEditor({ open: true, mode: 'dark' })}
+          >
+            + Nueva paleta oscura
+          </button>
+          <button
+            type="button"
+            className="btn ghost text-sm"
+            onClick={() => setEditor({ open: true, mode: 'light' })}
+          >
+            + Nueva paleta clara
+          </button>
+        </div>
+      )}
+
+      {/* Custom palette editor */}
+      {editor.open && (
+        <CustomPaletteEditor
+          mode={editor.mode}
+          initialValues={editor.editing}
+          onSave={handleSaveCustom}
+          onCancel={() => setEditor({ open: false })}
+        />
+      )}
+
+      {/* Save bar */}
+      {isDirty && (
+        <div
+          className="sticky bottom-4 rounded-xl border p-4 flex items-center justify-between gap-4"
+          style={{ background: 'var(--bg-2)', borderColor: 'var(--gold)' }}
+        >
+          <p className="text-sm" style={{ color: 'var(--fg-1)' }}>
+            Tienes cambios sin guardar.
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="btn ghost text-sm"
+              onClick={() => {
+                setPendingDarkId(null)
+                setPendingLightId(null)
+                setPendingCustom([])
+              }}
+            >
+              Descartar
+            </button>
+            <button
+              type="button"
+              className="btn primary text-sm"
+              onClick={() => setConfirmOpen(true)}
+            >
+              Aplicar paleta
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Confirm dialog */}
+      {confirmOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style={{ background: 'var(--overlay)' }}
+        >
+          <div
+            className="rounded-2xl border p-6 max-w-sm w-full space-y-4"
+            style={{ background: 'var(--bg-1)', borderColor: 'var(--line-2)' }}
+          >
+            <h3 className="text-lg font-bold" style={{ color: 'var(--fg-0)', fontFamily: 'var(--font-display)' }}>
+              Aplicar paleta
+            </h3>
+            <p className="text-sm" style={{ color: 'var(--fg-2)' }}>
+              Esta paleta se aplicará a toda la web para todos los usuarios. ¿Continuar?
+            </p>
+            <div className="flex gap-3">
+              <button
+                type="button"
+                className="btn ghost flex-1"
+                onClick={() => setConfirmOpen(false)}
+                disabled={isSaving}
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                className="btn primary flex-1"
+                onClick={handleConfirmSave}
+                disabled={isSaving}
+              >
+                {isSaving ? 'Guardando...' : 'Confirmar'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/appearance/AppearanceSection.tsx
+++ b/src/components/appearance/AppearanceSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { ColorThemeConfig, CustomPalette } from '@/domain/colorTheme'
-import { getPaletteById } from '@/domain/colorTheme'
+import { getPaletteById, DEFAULT_DARK_PALETTE_ID, DEFAULT_LIGHT_PALETTE_ID } from '@/domain/colorTheme'
 import { useColorTheme, useMutateColorTheme } from '@/hooks/useColorTheme'
 import { PalettePicker } from './PalettePicker'
 import { ThemePreview } from './ThemePreview'
@@ -24,8 +24,12 @@ export function AppearanceSection() {
   const activeLightId = pendingLightId ?? savedConfig?.activeLightPaletteId ?? null
   const customs = pendingCustom.length > 0 ? pendingCustom : (savedConfig?.customPalettes ?? [])
 
-  const darkTokens = activeDarkId ? getPaletteById(activeDarkId, customs)?.tokens ?? null : null
-  const lightTokens = activeLightId ? getPaletteById(activeLightId, customs)?.tokens ?? null : null
+  // When no palette is saved in DB, show the CSS defaults as "currently active" in the picker
+  const effectiveDarkId = activeDarkId ?? DEFAULT_DARK_PALETTE_ID
+  const effectiveLightId = activeLightId ?? DEFAULT_LIGHT_PALETTE_ID
+
+  const darkTokens = getPaletteById(effectiveDarkId, customs)?.tokens ?? null
+  const lightTokens = getPaletteById(effectiveLightId, customs)?.tokens ?? null
 
   const isDirty =
     activeDarkId !== (savedConfig?.activeDarkPaletteId ?? null) ||
@@ -101,8 +105,8 @@ export function AppearanceSection() {
           Paletas
         </h2>
         <PalettePicker
-          selectedDarkId={activeDarkId}
-          selectedLightId={activeLightId}
+          selectedDarkId={effectiveDarkId}
+          selectedLightId={effectiveLightId}
           customPalettes={customs}
           onSelectDark={(id) => setPendingDarkId(id)}
           onSelectLight={(id) => setPendingLightId(id)}

--- a/src/components/appearance/AppearanceSection.tsx
+++ b/src/components/appearance/AppearanceSection.tsx
@@ -11,7 +11,7 @@ type EditorState =
   | { open: true; mode: 'dark' | 'light'; editing?: CustomPalette }
 
 export function AppearanceSection() {
-  const { data: savedConfig, isLoading } = useColorTheme()
+  const { data: savedConfig, isLoading, isError } = useColorTheme()
   const { mutate: saveTheme, isPending: isSaving } = useMutateColorTheme()
 
   const [pendingDarkId, setPendingDarkId] = useState<string | null>(null)
@@ -67,6 +67,14 @@ export function AppearanceSection() {
     return (
       <div className="flex items-center justify-center py-16" style={{ color: 'var(--fg-3)' }}>
         Cargando...
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center py-16" style={{ color: 'var(--brick)' }}>
+        No se pudo cargar la configuración de color.
       </div>
     )
   }

--- a/src/components/appearance/CustomPaletteEditor.tsx
+++ b/src/components/appearance/CustomPaletteEditor.tsx
@@ -1,5 +1,6 @@
 import { useState, useId } from 'react'
 import type { CustomPalette, PaletteTokens } from '@/domain/colorTheme'
+import { deriveAccentVariant } from '@/domain/colorTheme'
 
 interface CustomPaletteEditorProps {
   mode: 'dark' | 'light'
@@ -8,24 +9,13 @@ interface CustomPaletteEditorProps {
   onCancel?: () => void
 }
 
-function deriveSecondary(hex: string, mode: 'dark' | 'light'): string {
-  const r = parseInt(hex.slice(1, 3), 16)
-  const g = parseInt(hex.slice(3, 5), 16)
-  const b = parseInt(hex.slice(5, 7), 16)
-  const mix = mode === 'dark' ? 180 : 80
-  const nr = Math.round(r + (mix - r) * 0.45)
-  const ng = Math.round(g + (mix - g) * 0.45)
-  const nb = Math.round(b + (mix - b) * 0.45)
-  return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`
-}
-
 function tokensFromBaseColors(led: string, gold: string, brick: string, mode: 'dark' | 'light'): PaletteTokens {
   return {
     led,
-    ledSoft: deriveSecondary(led, mode),
+    ledSoft: deriveAccentVariant(led, mode),
     gold,
     brick,
-    brickWarm: deriveSecondary(brick, mode),
+    brickWarm: deriveAccentVariant(brick, mode),
   }
 }
 
@@ -98,7 +88,7 @@ export function CustomPaletteEditor({ mode, onSave, initialValues, onCancel }: C
 
       {/* Preview swatches */}
       <div className="flex gap-1.5">
-        {[led, deriveSecondary(led, mode), gold, brick, deriveSecondary(brick, mode)].map((color, i) => (
+        {[led, deriveAccentVariant(led, mode), gold, brick, deriveAccentVariant(brick, mode)].map((color, i) => (
           <div key={i} className="h-4 flex-1 rounded-full" style={{ background: color }} />
         ))}
       </div>

--- a/src/components/appearance/CustomPaletteEditor.tsx
+++ b/src/components/appearance/CustomPaletteEditor.tsx
@@ -1,0 +1,124 @@
+import { useState, useId } from 'react'
+import type { CustomPalette, PaletteTokens } from '@/domain/colorTheme'
+
+interface CustomPaletteEditorProps {
+  mode: 'dark' | 'light'
+  onSave: (palette: CustomPalette) => void
+  initialValues?: CustomPalette
+  onCancel?: () => void
+}
+
+function deriveSecondary(hex: string, mode: 'dark' | 'light'): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  const mix = mode === 'dark' ? 180 : 80
+  const nr = Math.round(r + (mix - r) * 0.45)
+  const ng = Math.round(g + (mix - g) * 0.45)
+  const nb = Math.round(b + (mix - b) * 0.45)
+  return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`
+}
+
+function tokensFromBaseColors(led: string, gold: string, brick: string, mode: 'dark' | 'light'): PaletteTokens {
+  return {
+    led,
+    ledSoft: deriveSecondary(led, mode),
+    gold,
+    brick,
+    brickWarm: deriveSecondary(brick, mode),
+  }
+}
+
+export function CustomPaletteEditor({ mode, onSave, initialValues, onCancel }: CustomPaletteEditorProps) {
+  const uid = useId()
+  const [name, setName] = useState(initialValues?.name ?? '')
+  const [led, setLed] = useState(initialValues?.tokens.led ?? '#7b4fff')
+  const [gold, setGold] = useState(initialValues?.tokens.gold ?? '#c9a24a')
+  const [brick, setBrick] = useState(initialValues?.tokens.brick ?? '#8b3a1f')
+
+  function handleSave() {
+    if (!name.trim()) return
+    const tokens = tokensFromBaseColors(led, gold, brick, mode)
+    const palette: CustomPalette = {
+      id: initialValues?.id ?? `custom-${Date.now()}`,
+      name: name.trim(),
+      mode,
+      tokens,
+    }
+    onSave(palette)
+  }
+
+  return (
+    <div
+      className="rounded-xl border p-4 space-y-4"
+      style={{ borderColor: 'var(--line)', background: 'var(--bg-2)' }}
+    >
+      <h4 className="text-sm font-semibold" style={{ color: 'var(--fg-0)' }}>
+        {initialValues ? 'Editar paleta' : `Nueva paleta — ${mode === 'dark' ? 'oscuro' : 'claro'}`}
+      </h4>
+
+      {/* Name */}
+      <div className="space-y-1">
+        <label htmlFor={`${uid}-name`} className="text-[11px] font-semibold" style={{ color: 'var(--fg-2)' }}>
+          Nombre
+        </label>
+        <input
+          id={`${uid}-name`}
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Mi paleta..."
+          className="input w-full"
+        />
+      </div>
+
+      {/* Color pickers */}
+      <div className="grid grid-cols-3 gap-3">
+        {[
+          { label: 'Acento principal', value: led, set: setLed, id: `${uid}-led` },
+          { label: 'Tono dorado', value: gold, set: setGold, id: `${uid}-gold` },
+          { label: 'Acento secundario', value: brick, set: setBrick, id: `${uid}-brick` },
+        ].map(({ label, value, set, id }) => (
+          <div key={id} className="flex flex-col items-center gap-1.5">
+            <label htmlFor={id} className="text-[10px] text-center leading-tight" style={{ color: 'var(--fg-3)' }}>
+              {label}
+            </label>
+            <input
+              id={id}
+              type="color"
+              value={value}
+              onChange={(e) => set(e.target.value)}
+              className="w-10 h-10 rounded-lg cursor-pointer border-0"
+              style={{ padding: 2, background: 'transparent' }}
+            />
+            <span className="text-[9px] font-mono" style={{ color: 'var(--fg-3)' }}>{value}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Preview swatches */}
+      <div className="flex gap-1.5">
+        {[led, deriveSecondary(led, mode), gold, brick, deriveSecondary(brick, mode)].map((color, i) => (
+          <div key={i} className="h-4 flex-1 rounded-full" style={{ background: color }} />
+        ))}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!name.trim()}
+          className="btn primary flex-1 text-sm"
+        >
+          Guardar paleta
+        </button>
+        {onCancel && (
+          <button type="button" onClick={onCancel} className="btn ghost text-sm">
+            Cancelar
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/appearance/PaletteCard.tsx
+++ b/src/components/appearance/PaletteCard.tsx
@@ -1,0 +1,91 @@
+import type { ColorPalette, CustomPalette } from '@/domain/colorTheme'
+
+interface PaletteCardProps {
+  palette: ColorPalette | CustomPalette
+  isSelected: boolean
+  suggestedPair?: ColorPalette | CustomPalette
+  onClick: () => void
+  onEdit?: () => void
+}
+
+const SWATCH_KEYS: Array<keyof ColorPalette['tokens']> = [
+  'led', 'ledSoft', 'gold', 'brick', 'brickWarm',
+]
+
+export function PaletteCard({ palette, isSelected, suggestedPair, onClick, onEdit }: PaletteCardProps) {
+  const isPredefined = !('id' in palette && !('pairedWith' in palette))
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full text-left rounded-xl border p-3 transition-all"
+      style={{
+        borderColor: isSelected ? 'var(--gold)' : 'var(--line)',
+        background: isSelected ? 'color-mix(in srgb, var(--gold) 6%, var(--bg-2))' : 'var(--bg-2)',
+        boxShadow: isSelected ? '0 0 0 1px var(--gold)' : 'none',
+      }}
+    >
+      {/* Color swatches */}
+      <div className="flex gap-1.5 mb-2.5">
+        {SWATCH_KEYS.map((k) => (
+          <div
+            key={k}
+            className="h-5 flex-1 rounded-full"
+            style={{ background: palette.tokens[k] }}
+            title={k}
+          />
+        ))}
+      </div>
+
+      {/* Name */}
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[13px] font-semibold leading-tight truncate" style={{ color: 'var(--fg-0)' }}>
+            {'name' in palette && 'nameEs' in palette
+              ? (palette as ColorPalette).name
+              : palette.name}
+          </p>
+          {'nameEs' in palette && (
+            <p className="text-[11px] leading-tight truncate" style={{ color: 'var(--fg-3)' }}>
+              {(palette as ColorPalette).nameEs}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col items-end gap-1 shrink-0">
+          <span
+            className="text-[9px] font-bold tracking-widest uppercase px-1.5 py-0.5 rounded"
+            style={{
+              background: palette.mode === 'dark' ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
+              color: 'var(--fg-3)',
+            }}
+          >
+            {palette.mode === 'dark' ? 'DARK' : 'LIGHT'}
+          </span>
+          {isSelected && (
+            <span className="text-[9px] font-bold" style={{ color: 'var(--gold)' }}>✓</span>
+          )}
+        </div>
+      </div>
+
+      {/* Suggested pair */}
+      {suggestedPair && (
+        <p className="mt-1.5 text-[10px]" style={{ color: 'var(--fg-3)' }}>
+          Pareja: {suggestedPair.name}
+        </p>
+      )}
+
+      {/* Edit button for custom palettes */}
+      {onEdit && !isPredefined && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onEdit() }}
+          className="mt-2 text-[10px] underline"
+          style={{ color: 'var(--led-soft)' }}
+        >
+          Editar
+        </button>
+      )}
+    </button>
+  )
+}

--- a/src/components/appearance/PaletteCard.tsx
+++ b/src/components/appearance/PaletteCard.tsx
@@ -16,10 +16,12 @@ export function PaletteCard({ palette, isSelected, suggestedPair, onClick, onEdi
   const isPredefined = !('id' in palette && !('pairedWith' in palette))
 
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
-      className="w-full text-left rounded-xl border p-3 transition-all"
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } }}
+      className="w-full text-left rounded-xl border p-3 transition-all cursor-pointer"
       style={{
         borderColor: isSelected ? 'var(--gold)' : 'var(--line)',
         background: isSelected ? 'color-mix(in srgb, var(--gold) 6%, var(--bg-2))' : 'var(--bg-2)',
@@ -86,6 +88,6 @@ export function PaletteCard({ palette, isSelected, suggestedPair, onClick, onEdi
           Editar
         </button>
       )}
-    </button>
+    </div>
   )
 }

--- a/src/components/appearance/PalettePicker.tsx
+++ b/src/components/appearance/PalettePicker.tsx
@@ -1,0 +1,103 @@
+import type { ColorPalette, CustomPalette } from '@/domain/colorTheme'
+import { PREDEFINED_PALETTES, getPaletteById } from '@/domain/colorTheme'
+import { PaletteCard } from './PaletteCard'
+
+interface PalettePickerProps {
+  selectedDarkId: string | null
+  selectedLightId: string | null
+  customPalettes: CustomPalette[]
+  onSelectDark: (id: string) => void
+  onSelectLight: (id: string) => void
+  onEditCustom?: (palette: CustomPalette) => void
+}
+
+const DARK_PREDEFINED = PREDEFINED_PALETTES.filter((p) => p.mode === 'dark')
+const LIGHT_PREDEFINED = PREDEFINED_PALETTES.filter((p) => p.mode === 'light')
+
+export function PalettePicker({
+  selectedDarkId,
+  selectedLightId,
+  customPalettes,
+  onSelectDark,
+  onSelectLight,
+  onEditCustom,
+}: PalettePickerProps) {
+  const customDark = customPalettes.filter((p) => p.mode === 'dark')
+  const customLight = customPalettes.filter((p) => p.mode === 'light')
+
+  function renderDarkSection() {
+    const palettes: Array<ColorPalette | CustomPalette> = [...DARK_PREDEFINED, ...customDark]
+    return palettes.map((palette) => {
+      const pairedWith =
+        'pairedWith' in palette
+          ? (getPaletteById(palette.pairedWith, customPalettes) as ColorPalette | undefined)
+          : undefined
+      return (
+        <PaletteCard
+          key={palette.id}
+          palette={palette}
+          isSelected={selectedDarkId === palette.id}
+          suggestedPair={pairedWith}
+          onClick={() => onSelectDark(palette.id)}
+          onEdit={
+            !('pairedWith' in palette) && onEditCustom
+              ? () => onEditCustom(palette as CustomPalette)
+              : undefined
+          }
+        />
+      )
+    })
+  }
+
+  function renderLightSection() {
+    const palettes: Array<ColorPalette | CustomPalette> = [...LIGHT_PREDEFINED, ...customLight]
+    return palettes.map((palette) => {
+      const pairedWith =
+        'pairedWith' in palette
+          ? (getPaletteById(palette.pairedWith, customPalettes) as ColorPalette | undefined)
+          : undefined
+      return (
+        <PaletteCard
+          key={palette.id}
+          palette={palette}
+          isSelected={selectedLightId === palette.id}
+          suggestedPair={pairedWith}
+          onClick={() => onSelectLight(palette.id)}
+          onEdit={
+            !('pairedWith' in palette) && onEditCustom
+              ? () => onEditCustom(palette as CustomPalette)
+              : undefined
+          }
+        />
+      )
+    })
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3
+          className="text-[11px] font-bold tracking-[0.2em] uppercase mb-3"
+          style={{ color: 'var(--fg-3)' }}
+        >
+          Modo oscuro
+        </h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {renderDarkSection()}
+        </div>
+      </div>
+
+      <div>
+        <h3
+          className="text-[11px] font-bold tracking-[0.2em] uppercase mb-3"
+          style={{ color: 'var(--fg-3)' }}
+        >
+          Modo claro
+        </h3>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {renderLightSection()}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/appearance/PreviewAppointmentsMock.tsx
+++ b/src/components/appearance/PreviewAppointmentsMock.tsx
@@ -1,0 +1,83 @@
+export function PreviewAppointmentsMock() {
+  return (
+    <div style={{ background: 'var(--bg-0)', minHeight: 240, fontFamily: 'var(--font-ui, sans-serif)', display: 'flex', flexDirection: 'column' }}>
+      {/* TopBar */}
+      <div style={{ background: 'var(--bg-1)', borderBottom: '1px solid var(--line)', padding: '0 12px', height: 28, display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <span style={{ fontSize: 9, fontWeight: 700, color: 'var(--fg-1)', fontFamily: 'var(--font-display, serif)', letterSpacing: '0.06em' }}>GIO BARBER</span>
+        <span style={{ fontSize: 8, color: 'var(--fg-3)' }}>●  ○</span>
+      </div>
+
+      {/* Content */}
+      <div style={{ flex: 1, display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, padding: 8 }}>
+
+        {/* Left — appointments list */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {/* Next appointment */}
+          <div style={{ background: 'var(--bg-2)', border: '1px solid var(--line)', borderRadius: 8, padding: '6px 8px' }}>
+            <div style={{ fontSize: 7, fontWeight: 700, letterSpacing: '0.15em', color: 'var(--fg-3)', marginBottom: 4 }}>PRÓXIMA CITA</div>
+            <div style={{ fontSize: 8, fontWeight: 600, color: 'var(--fg-1)' }}>Corte clásico</div>
+            <div style={{ fontSize: 7, color: 'var(--fg-3)', marginTop: 1 }}>lun 12 may · 11:00</div>
+            <div style={{ marginTop: 4, display: 'inline-block', background: 'color-mix(in srgb, var(--led) 15%, transparent)', color: 'var(--led)', fontSize: 7, padding: '1px 5px', borderRadius: 3, fontWeight: 600 }}>Confirmada</div>
+          </div>
+
+          {/* History */}
+          <div style={{ background: 'var(--bg-2)', border: '1px solid var(--line)', borderRadius: 8, padding: '6px 8px', flex: 1 }}>
+            <div style={{ fontSize: 7, fontWeight: 700, letterSpacing: '0.15em', color: 'var(--fg-3)', marginBottom: 4 }}>HISTORIAL</div>
+            {[['Corte + barba', 'abr 28'], ['Fade', 'abr 10']].map(([label, date]) => (
+              <div key={label} style={{ display: 'flex', justifyContent: 'space-between', padding: '3px 0', borderBottom: '1px solid var(--line)' }}>
+                <span style={{ fontSize: 7, color: 'var(--fg-2)' }}>{label}</span>
+                <span style={{ fontSize: 7, color: 'var(--fg-3)' }}>{date}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Right — loyalty card */}
+        <div
+          data-theme="dark"
+          style={{
+            background: 'linear-gradient(135deg, #0d0d10 0%, #1a1a20 50%, #0d0d10 100%)',
+            border: '1px solid color-mix(in srgb, var(--card-accent) 30%, transparent)',
+            borderRadius: 8,
+            padding: '8px',
+            position: 'relative',
+            overflow: 'hidden',
+          }}
+        >
+          {/* Ambient glow */}
+          <div style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, background: 'radial-gradient(circle at 80% 20%, color-mix(in srgb, var(--card-accent) 8%, transparent) 0%, transparent 60%)', pointerEvents: 'none' }} />
+
+          {/* Header */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 6 }}>
+            <div>
+              <div style={{ fontSize: 7, letterSpacing: '0.15em', color: 'var(--card-accent)', fontWeight: 700 }}>GIO BLACK CARD</div>
+              <div style={{ fontSize: 16, fontWeight: 700, color: '#fff', lineHeight: 1.1 }}>
+                42 <span style={{ fontSize: 8, color: 'var(--card-accent)' }}>pts</span>
+              </div>
+            </div>
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ fontSize: 7, color: 'color-mix(in srgb, var(--card-accent) 50%, transparent)' }}>MIEMBRO</div>
+              <div style={{ fontSize: 7, color: 'var(--card-accent)', letterSpacing: '0.1em' }}>A4F2</div>
+            </div>
+          </div>
+
+          {/* Progress bar */}
+          <div style={{ position: 'relative', height: 6, background: 'rgba(255,255,255,0.07)', borderRadius: 4, marginBottom: 5 }}>
+            <div style={{ position: 'absolute', top: 0, left: 0, bottom: 0, width: '42%', background: `linear-gradient(90deg, var(--brick), var(--card-accent))`, borderRadius: 4, boxShadow: '0 0 6px color-mix(in srgb, var(--card-accent) 55%, transparent)' }} />
+          </div>
+
+          {/* Labels */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 5 }}>
+            <span style={{ fontSize: 7, color: 'rgba(255,255,255,0.3)' }}>0</span>
+            <span style={{ fontSize: 7, color: 'rgba(255,255,255,0.3)' }}>100 pts</span>
+          </div>
+
+          {/* Next reward */}
+          <div style={{ background: 'color-mix(in srgb, var(--card-accent) 8%, transparent)', border: '1px solid color-mix(in srgb, var(--card-accent) 18%, transparent)', borderRadius: 5, padding: '3px 6px' }}>
+            <span style={{ fontSize: 7, color: 'var(--card-accent)' }}>★ <strong>58 pts</strong> para Cerveza gratis</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/appearance/PreviewCalendarMock.tsx
+++ b/src/components/appearance/PreviewCalendarMock.tsx
@@ -2,37 +2,35 @@ const DAYS = ['L', 'M', 'X', 'J', 'V', 'S', 'D']
 const DATES = [5, 6, 7, 8, 9, 10, 11]
 const SLOTS = ['10:00', '10:30', '11:00', '11:30', '12:00', '12:30']
 const BUSY = new Set(['10:30', '11:30'])
+const SELECTED = '11:00'
 
 export function PreviewCalendarMock() {
   return (
     <div
-      className="rounded-lg overflow-hidden"
-      style={{ background: 'var(--bg-1, #1a1a1a)', fontFamily: 'var(--font-sans, sans-serif)' }}
+      style={{
+        borderRadius: 8,
+        overflow: 'hidden',
+        background: 'var(--bg-1)',
+        fontFamily: 'var(--font-ui)',
+      }}
     >
-      {/* Header */}
-      <div
-        className="px-4 py-3 flex items-center justify-between border-b"
-        style={{ borderColor: 'var(--line, rgba(255,255,255,0.1))' }}
-      >
-        <span className="text-xs font-semibold" style={{ color: 'var(--fg-0, #fff)' }}>
-          Reservar cita
-        </span>
-        <span className="text-[10px]" style={{ color: 'var(--fg-3, rgba(255,255,255,0.4))' }}>
-          Mayo 2026
-        </span>
+      {/* Section label */}
+      <div style={{ padding: '10px 12px 4px' }}>
+        <p style={{ margin: 0, fontSize: 8, letterSpacing: '0.2em', fontWeight: 600, textTransform: 'uppercase', color: 'var(--fg-3)' }}>
+          Seleccionar fecha
+        </p>
       </div>
 
       {/* Day strip */}
-      <div className="grid grid-cols-7 gap-1 px-3 py-3">
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 2, padding: '4px 12px 8px' }}>
         {DAYS.map((d, i) => (
-          <div key={d} className="flex flex-col items-center gap-1">
-            <span className="text-[9px]" style={{ color: 'var(--fg-3, rgba(255,255,255,0.4))' }}>{d}</span>
+          <div key={d} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
+            <span style={{ fontSize: 8, color: 'var(--fg-3)' }}>{d}</span>
             <div
-              className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-semibold"
               style={
                 i === 2
-                  ? { background: 'var(--led)', color: '#fff' }
-                  : { color: 'var(--fg-1, rgba(255,255,255,0.8))' }
+                  ? { width: 22, height: 22, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 9, fontWeight: 700, background: 'var(--led)', color: '#fff' }
+                  : { width: 22, height: 22, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 9, color: 'var(--fg-1)' }
               }
             >
               {DATES[i]}
@@ -41,40 +39,21 @@ export function PreviewCalendarMock() {
         ))}
       </div>
 
-      {/* Slots */}
-      <div
-        className="px-3 pb-3 border-t"
-        style={{ borderColor: 'var(--line, rgba(255,255,255,0.1))' }}
-      >
-        <p
-          className="text-[9px] tracking-widest uppercase py-2"
-          style={{ color: 'var(--fg-3, rgba(255,255,255,0.4))' }}
-        >
-          Horas disponibles
+      {/* Hour section */}
+      <div style={{ padding: '8px 12px 6px', borderTop: '1px solid var(--line)' }}>
+        <p style={{ margin: '0 0 6px', fontSize: 8, letterSpacing: '0.2em', fontWeight: 600, textTransform: 'uppercase', color: 'var(--fg-3)' }}>
+          Hora — miércoles 7
         </p>
-        <div className="grid grid-cols-3 gap-1.5">
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 4 }}>
           {SLOTS.map((slot) => (
             <div
               key={slot}
-              className="rounded-lg py-1.5 text-center text-[10px] font-medium border"
               style={
                 BUSY.has(slot)
-                  ? {
-                      borderColor: 'rgba(255,255,255,0.05)',
-                      color: 'rgba(255,255,255,0.2)',
-                      background: 'rgba(255,255,255,0.02)',
-                      textDecoration: 'line-through',
-                    }
-                  : slot === '12:00'
-                  ? {
-                      borderColor: 'var(--led)',
-                      color: 'var(--led)',
-                      background: `color-mix(in srgb, var(--led) 10%, transparent)`,
-                    }
-                  : {
-                      borderColor: 'var(--line, rgba(255,255,255,0.1))',
-                      color: 'var(--fg-1, rgba(255,255,255,0.8))',
-                    }
+                  ? { padding: '4px 0', borderRadius: 5, textAlign: 'center', fontSize: 8, fontWeight: 500, border: '1px solid var(--line)', color: 'var(--fg-3)', textDecoration: 'line-through' }
+                  : slot === SELECTED
+                  ? { padding: '4px 0', borderRadius: 5, textAlign: 'center', fontSize: 8, fontWeight: 700, border: '1px solid var(--led)', background: 'var(--led)', color: '#fff' }
+                  : { padding: '4px 0', borderRadius: 5, textAlign: 'center', fontSize: 8, fontWeight: 500, border: '1px solid var(--line)', color: 'var(--fg-1)' }
               }
             >
               {slot}
@@ -84,10 +63,18 @@ export function PreviewCalendarMock() {
       </div>
 
       {/* CTA */}
-      <div className="px-3 pb-3">
+      <div style={{ padding: '6px 12px 10px' }}>
         <div
-          className="w-full rounded-lg py-2 text-center text-[11px] font-bold"
-          style={{ background: 'var(--led)', color: '#fff' }}
+          style={{
+            width: '100%',
+            padding: '7px 0',
+            borderRadius: 7,
+            textAlign: 'center',
+            fontSize: 9,
+            fontWeight: 700,
+            background: 'var(--led)',
+            color: '#fff',
+          }}
         >
           Confirmar reserva
         </div>

--- a/src/components/appearance/PreviewCalendarMock.tsx
+++ b/src/components/appearance/PreviewCalendarMock.tsx
@@ -1,0 +1,97 @@
+const DAYS = ['L', 'M', 'X', 'J', 'V', 'S', 'D']
+const DATES = [5, 6, 7, 8, 9, 10, 11]
+const SLOTS = ['10:00', '10:30', '11:00', '11:30', '12:00', '12:30']
+const BUSY = new Set(['10:30', '11:30'])
+
+export function PreviewCalendarMock() {
+  return (
+    <div
+      className="rounded-lg overflow-hidden"
+      style={{ background: 'var(--bg-1, #1a1a1a)', fontFamily: 'var(--font-sans, sans-serif)' }}
+    >
+      {/* Header */}
+      <div
+        className="px-4 py-3 flex items-center justify-between border-b"
+        style={{ borderColor: 'var(--line, rgba(255,255,255,0.1))' }}
+      >
+        <span className="text-xs font-semibold" style={{ color: 'var(--fg-0, #fff)' }}>
+          Reservar cita
+        </span>
+        <span className="text-[10px]" style={{ color: 'var(--fg-3, rgba(255,255,255,0.4))' }}>
+          Mayo 2026
+        </span>
+      </div>
+
+      {/* Day strip */}
+      <div className="grid grid-cols-7 gap-1 px-3 py-3">
+        {DAYS.map((d, i) => (
+          <div key={d} className="flex flex-col items-center gap-1">
+            <span className="text-[9px]" style={{ color: 'var(--fg-3, rgba(255,255,255,0.4))' }}>{d}</span>
+            <div
+              className="w-7 h-7 rounded-full flex items-center justify-center text-[10px] font-semibold"
+              style={
+                i === 2
+                  ? { background: 'var(--led)', color: '#fff' }
+                  : { color: 'var(--fg-1, rgba(255,255,255,0.8))' }
+              }
+            >
+              {DATES[i]}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Slots */}
+      <div
+        className="px-3 pb-3 border-t"
+        style={{ borderColor: 'var(--line, rgba(255,255,255,0.1))' }}
+      >
+        <p
+          className="text-[9px] tracking-widest uppercase py-2"
+          style={{ color: 'var(--fg-3, rgba(255,255,255,0.4))' }}
+        >
+          Horas disponibles
+        </p>
+        <div className="grid grid-cols-3 gap-1.5">
+          {SLOTS.map((slot) => (
+            <div
+              key={slot}
+              className="rounded-lg py-1.5 text-center text-[10px] font-medium border"
+              style={
+                BUSY.has(slot)
+                  ? {
+                      borderColor: 'rgba(255,255,255,0.05)',
+                      color: 'rgba(255,255,255,0.2)',
+                      background: 'rgba(255,255,255,0.02)',
+                      textDecoration: 'line-through',
+                    }
+                  : slot === '12:00'
+                  ? {
+                      borderColor: 'var(--led)',
+                      color: 'var(--led)',
+                      background: `color-mix(in srgb, var(--led) 10%, transparent)`,
+                    }
+                  : {
+                      borderColor: 'var(--line, rgba(255,255,255,0.1))',
+                      color: 'var(--fg-1, rgba(255,255,255,0.8))',
+                    }
+              }
+            >
+              {slot}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* CTA */}
+      <div className="px-3 pb-3">
+        <div
+          className="w-full rounded-lg py-2 text-center text-[11px] font-bold"
+          style={{ background: 'var(--led)', color: '#fff' }}
+        >
+          Confirmar reserva
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/appearance/PreviewHeroMock.tsx
+++ b/src/components/appearance/PreviewHeroMock.tsx
@@ -1,73 +1,100 @@
+const NAV_ITEMS = ['Servicios', 'Horarios', 'Barberos', 'Fidelización', 'Barbería']
+const SERVICES = [
+  { name: 'Corte de pelo', duration: '30 min', price: '18€' },
+  { name: 'Arreglo de barba', duration: '20 min', price: '14€' },
+]
+
 export function PreviewHeroMock() {
   return (
     <div
-      className="relative overflow-hidden rounded-lg"
-      style={{ background: 'var(--bg-0)', fontFamily: 'var(--font-display)' }}
+      style={{
+        display: 'flex',
+        borderRadius: 8,
+        overflow: 'hidden',
+        background: 'var(--bg-1)',
+        fontFamily: 'var(--font-ui)',
+        minHeight: 180,
+      }}
     >
-      {/* Hero */}
+      {/* Sidebar */}
       <div
-        className="flex flex-col items-center justify-center px-4 py-8 text-center"
-        style={{ background: '#1A1A1A' }}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          padding: 6,
+          background: 'var(--bg-2)',
+          width: 88,
+          flexShrink: 0,
+          borderRight: '1px solid var(--line)',
+        }}
       >
-        <p
-          className="text-xs tracking-[0.25em] font-semibold uppercase mb-3"
-          style={{ color: 'var(--gold)' }}
-        >
-          Barcelona · Est. 2019
-        </p>
-        <h2
-          className="text-3xl font-bold leading-none mb-3"
-          style={{ color: 'var(--fg-0, #fff)', fontFamily: 'var(--font-display)' }}
-        >
-          Gio<br />
-          <span style={{ color: 'var(--gold)' }}>Barber</span><br />
-          Shop
-        </h2>
-        <p className="text-xs mb-5 max-w-[160px] leading-relaxed" style={{ color: 'rgba(255,255,255,0.45)' }}>
-          Barbería premium. Reserva online y acumula puntos.
-        </p>
-        <div className="flex gap-2">
+        {NAV_ITEMS.map((item, i) => (
           <div
-            className="rounded-lg px-4 py-2 text-xs font-bold"
-            style={{ background: 'var(--gold)', color: '#000' }}
+            key={item}
+            style={
+              i === 0
+                ? {
+                    padding: '5px 8px',
+                    borderRadius: 6,
+                    fontSize: 9,
+                    fontWeight: 600,
+                    color: 'var(--led)',
+                    background: `color-mix(in srgb, var(--led) 12%, transparent)`,
+                    borderLeft: '2px solid var(--led)',
+                  }
+                : {
+                    padding: '5px 8px',
+                    borderRadius: 6,
+                    fontSize: 9,
+                    fontWeight: 400,
+                    color: 'var(--fg-2)',
+                  }
+            }
           >
-            Reservar
+            {item}
           </div>
-          <div
-            className="rounded-lg px-4 py-2 text-xs font-semibold border"
-            style={{ borderColor: 'rgba(255,255,255,0.2)', color: 'rgba(255,255,255,0.7)' }}
-          >
-            Entrar
-          </div>
-        </div>
+        ))}
       </div>
 
-      {/* Servicios */}
-      <div className="px-4 py-5" style={{ background: '#111' }}>
-        <p className="text-center text-[10px] tracking-[0.25em] uppercase mb-3" style={{ color: 'var(--gold)' }}>
+      {/* Content */}
+      <div style={{ flex: 1, padding: 10, display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <p style={{ fontSize: 8, letterSpacing: '0.18em', fontWeight: 600, textTransform: 'uppercase', color: 'var(--fg-3)', margin: 0 }}>
           Servicios
         </p>
-        <div className="grid grid-cols-3 gap-2">
-          {[
-            { name: 'Corte', price: '18€' },
-            { name: 'Barba', price: '14€' },
-            { name: 'Corte+Barba', price: '28€' },
-          ].map(({ name, price }) => (
-            <div
-              key={name}
-              className="flex flex-col items-center text-center rounded-lg p-3 border"
-              style={{ borderColor: 'rgba(255,255,255,0.08)', background: 'rgba(255,255,255,0.03)' }}
-            >
-              <div
-                className="w-7 h-7 rounded-full flex items-center justify-center mb-2 text-[10px] font-bold"
-                style={{ background: `color-mix(in srgb, var(--gold) 15%, transparent)`, color: 'var(--gold)' }}
-              >
-                ✂
-              </div>
-              <div className="text-[10px] font-semibold mb-0.5" style={{ color: '#fff' }}>{name}</div>
-              <div className="text-xs font-bold" style={{ color: 'var(--gold)' }}>{price}</div>
+        {SERVICES.map((s) => (
+          <div
+            key={s.name}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: '6px 8px',
+              borderRadius: 6,
+              background: 'var(--bg-3)',
+              border: '1px solid var(--line)',
+            }}
+          >
+            <div>
+              <div style={{ fontSize: 9, fontWeight: 600, color: 'var(--fg-0)' }}>{s.name}</div>
+              <div style={{ fontSize: 8, color: 'var(--fg-3)' }}>{s.duration}</div>
             </div>
-          ))}
+            <div style={{ fontSize: 9, fontWeight: 700, color: 'var(--gold)' }}>{s.price}</div>
+          </div>
+        ))}
+        <div
+          style={{
+            width: '100%',
+            padding: '5px 0',
+            borderRadius: 6,
+            textAlign: 'center',
+            fontSize: 8,
+            fontWeight: 700,
+            background: 'var(--led)',
+            color: '#fff',
+          }}
+        >
+          + Añadir servicio
         </div>
       </div>
     </div>

--- a/src/components/appearance/PreviewHeroMock.tsx
+++ b/src/components/appearance/PreviewHeroMock.tsx
@@ -1,0 +1,75 @@
+export function PreviewHeroMock() {
+  return (
+    <div
+      className="relative overflow-hidden rounded-lg"
+      style={{ background: 'var(--bg-0)', fontFamily: 'var(--font-display)' }}
+    >
+      {/* Hero */}
+      <div
+        className="flex flex-col items-center justify-center px-4 py-8 text-center"
+        style={{ background: '#1A1A1A' }}
+      >
+        <p
+          className="text-xs tracking-[0.25em] font-semibold uppercase mb-3"
+          style={{ color: 'var(--gold)' }}
+        >
+          Barcelona · Est. 2019
+        </p>
+        <h2
+          className="text-3xl font-bold leading-none mb-3"
+          style={{ color: 'var(--fg-0, #fff)', fontFamily: 'var(--font-display)' }}
+        >
+          Gio<br />
+          <span style={{ color: 'var(--gold)' }}>Barber</span><br />
+          Shop
+        </h2>
+        <p className="text-xs mb-5 max-w-[160px] leading-relaxed" style={{ color: 'rgba(255,255,255,0.45)' }}>
+          Barbería premium. Reserva online y acumula puntos.
+        </p>
+        <div className="flex gap-2">
+          <div
+            className="rounded-lg px-4 py-2 text-xs font-bold"
+            style={{ background: 'var(--gold)', color: '#000' }}
+          >
+            Reservar
+          </div>
+          <div
+            className="rounded-lg px-4 py-2 text-xs font-semibold border"
+            style={{ borderColor: 'rgba(255,255,255,0.2)', color: 'rgba(255,255,255,0.7)' }}
+          >
+            Entrar
+          </div>
+        </div>
+      </div>
+
+      {/* Servicios */}
+      <div className="px-4 py-5" style={{ background: '#111' }}>
+        <p className="text-center text-[10px] tracking-[0.25em] uppercase mb-3" style={{ color: 'var(--gold)' }}>
+          Servicios
+        </p>
+        <div className="grid grid-cols-3 gap-2">
+          {[
+            { name: 'Corte', price: '18€' },
+            { name: 'Barba', price: '14€' },
+            { name: 'Corte+Barba', price: '28€' },
+          ].map(({ name, price }) => (
+            <div
+              key={name}
+              className="flex flex-col items-center text-center rounded-lg p-3 border"
+              style={{ borderColor: 'rgba(255,255,255,0.08)', background: 'rgba(255,255,255,0.03)' }}
+            >
+              <div
+                className="w-7 h-7 rounded-full flex items-center justify-center mb-2 text-[10px] font-bold"
+                style={{ background: `color-mix(in srgb, var(--gold) 15%, transparent)`, color: 'var(--gold)' }}
+              >
+                ✂
+              </div>
+              <div className="text-[10px] font-semibold mb-0.5" style={{ color: '#fff' }}>{name}</div>
+              <div className="text-xs font-bold" style={{ color: 'var(--gold)' }}>{price}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/appearance/ThemePreview.tsx
+++ b/src/components/appearance/ThemePreview.tsx
@@ -14,6 +14,7 @@ function toVars(tokens: PaletteTokens): React.CSSProperties {
     '--gold': tokens.gold,
     '--brick': tokens.brick,
     '--brick-warm': tokens.brickWarm,
+    '--card-accent': tokens.cardAccent ?? tokens.gold,
   } as React.CSSProperties
 }
 

--- a/src/components/appearance/ThemePreview.tsx
+++ b/src/components/appearance/ThemePreview.tsx
@@ -23,7 +23,7 @@ export function ThemePreview({ darkTokens, lightTokens }: ThemePreviewProps) {
       {/* Dark preview */}
       <div className="space-y-1.5">
         <p className="text-[11px] font-semibold tracking-widest uppercase" style={{ color: 'var(--fg-3)' }}>
-          Modo oscuro — Inicio
+          Modo oscuro — Configuración
         </p>
         <div
           style={darkTokens ? toVars(darkTokens) : undefined}

--- a/src/components/appearance/ThemePreview.tsx
+++ b/src/components/appearance/ThemePreview.tsx
@@ -1,5 +1,5 @@
 import type { PaletteTokens } from '@/domain/colorTheme'
-import { PreviewHeroMock } from './PreviewHeroMock'
+import { PreviewAppointmentsMock } from './PreviewAppointmentsMock'
 import { PreviewCalendarMock } from './PreviewCalendarMock'
 
 interface ThemePreviewProps {
@@ -23,13 +23,13 @@ export function ThemePreview({ darkTokens, lightTokens }: ThemePreviewProps) {
       {/* Dark preview */}
       <div className="space-y-1.5">
         <p className="text-[11px] font-semibold tracking-widest uppercase" style={{ color: 'var(--fg-3)' }}>
-          Modo oscuro — Configuración
+          Modo oscuro — Mis citas
         </p>
         <div
           style={darkTokens ? toVars(darkTokens) : undefined}
           className="pointer-events-none select-none rounded-xl overflow-hidden ring-1 ring-white/10"
         >
-          <PreviewHeroMock />
+          <PreviewAppointmentsMock />
         </div>
       </div>
 

--- a/src/components/appearance/ThemePreview.tsx
+++ b/src/components/appearance/ThemePreview.tsx
@@ -1,0 +1,51 @@
+import type { PaletteTokens } from '@/domain/colorTheme'
+import { PreviewHeroMock } from './PreviewHeroMock'
+import { PreviewCalendarMock } from './PreviewCalendarMock'
+
+interface ThemePreviewProps {
+  darkTokens: PaletteTokens | null
+  lightTokens: PaletteTokens | null
+}
+
+function toVars(tokens: PaletteTokens): React.CSSProperties {
+  return {
+    '--led': tokens.led,
+    '--led-soft': tokens.ledSoft,
+    '--gold': tokens.gold,
+    '--brick': tokens.brick,
+    '--brick-warm': tokens.brickWarm,
+  } as React.CSSProperties
+}
+
+export function ThemePreview({ darkTokens, lightTokens }: ThemePreviewProps) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {/* Dark preview */}
+      <div className="space-y-1.5">
+        <p className="text-[11px] font-semibold tracking-widest uppercase" style={{ color: 'var(--fg-3)' }}>
+          Modo oscuro — Inicio
+        </p>
+        <div
+          style={darkTokens ? toVars(darkTokens) : undefined}
+          className="pointer-events-none select-none rounded-xl overflow-hidden ring-1 ring-white/10"
+        >
+          <PreviewHeroMock />
+        </div>
+      </div>
+
+      {/* Light preview */}
+      <div className="space-y-1.5">
+        <p className="text-[11px] font-semibold tracking-widest uppercase" style={{ color: 'var(--fg-3)' }}>
+          Modo claro — Reservar
+        </p>
+        <div
+          data-theme="light"
+          style={lightTokens ? toVars(lightTokens) : undefined}
+          className="pointer-events-none select-none rounded-xl overflow-hidden ring-1 ring-black/10"
+        >
+          <PreviewCalendarMock />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/appearance/ThemePreview.tsx
+++ b/src/components/appearance/ThemePreview.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react'
 import type { PaletteTokens } from '@/domain/colorTheme'
 import { PreviewAppointmentsMock } from './PreviewAppointmentsMock'
 import { PreviewCalendarMock } from './PreviewCalendarMock'
@@ -7,7 +8,7 @@ interface ThemePreviewProps {
   lightTokens: PaletteTokens | null
 }
 
-function toVars(tokens: PaletteTokens): React.CSSProperties {
+function toVars(tokens: PaletteTokens): CSSProperties {
   return {
     '--led': tokens.led,
     '--led-soft': tokens.ledSoft,
@@ -15,7 +16,7 @@ function toVars(tokens: PaletteTokens): React.CSSProperties {
     '--brick': tokens.brick,
     '--brick-warm': tokens.brickWarm,
     '--card-accent': tokens.cardAccent ?? tokens.gold,
-  } as React.CSSProperties
+  } as CSSProperties
 }
 
 export function ThemePreview({ darkTokens, lightTokens }: ThemePreviewProps) {

--- a/src/components/appearance/index.ts
+++ b/src/components/appearance/index.ts
@@ -1,0 +1,7 @@
+export { PreviewHeroMock } from './PreviewHeroMock'
+export { PreviewCalendarMock } from './PreviewCalendarMock'
+export { ThemePreview } from './ThemePreview'
+export { PaletteCard } from './PaletteCard'
+export { PalettePicker } from './PalettePicker'
+export { CustomPaletteEditor } from './CustomPaletteEditor'
+export { AppearanceSection } from './AppearanceSection'

--- a/src/components/appearance/index.ts
+++ b/src/components/appearance/index.ts
@@ -1,4 +1,5 @@
 export { PreviewHeroMock } from './PreviewHeroMock'
+export { PreviewAppointmentsMock } from './PreviewAppointmentsMock'
 export { PreviewCalendarMock } from './PreviewCalendarMock'
 export { ThemePreview } from './ThemePreview'
 export { PaletteCard } from './PaletteCard'

--- a/src/components/loyalty/LoyaltyCard.tsx
+++ b/src/components/loyalty/LoyaltyCard.tsx
@@ -32,7 +32,7 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
       className="p-4 md:p-5"
       style={{
         background: 'linear-gradient(135deg, #0d0d10 0%, #1a1a20 50%, #0d0d10 100%)',
-        border: '1px solid rgba(201,162,74,0.3)',
+        border: '1px solid color-mix(in srgb, var(--gold) 30%, transparent)',
         borderRadius: 12,
         position: 'relative',
         overflow: 'hidden',
@@ -41,7 +41,7 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
       {/* Ambient glow */}
       <div style={{
         position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
-        background: 'radial-gradient(circle at 80% 20%, rgba(201,162,74,0.06) 0%, transparent 60%)',
+        background: 'radial-gradient(circle at 80% 20%, color-mix(in srgb, var(--gold) 6%, transparent) 0%, transparent 60%)',
         pointerEvents: 'none',
       }} />
 
@@ -57,7 +57,7 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
           </div>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
-          <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10, color: 'rgba(201,162,74,0.5)' }}>MIEMBRO</div>
+          <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10, color: 'color-mix(in srgb, var(--gold) 50%, transparent)' }}>MIEMBRO</div>
           <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 11, color: 'var(--gold)', letterSpacing: '0.1em' }}>{memberCode}</div>
         </div>
       </div>
@@ -91,13 +91,13 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
                 </span>
                 <span style={{
                   fontFamily: 'var(--font-mono, monospace)', fontSize: 8,
-                  color: m.reached ? 'rgba(201,162,74,0.7)' : 'rgba(255,255,255,0.2)',
+                  color: m.reached ? 'color-mix(in srgb, var(--gold) 70%, transparent)' : 'rgba(255,255,255,0.2)',
                 }}>
                   {m.pts}
                 </span>
                 <div style={{
                   width: 1, height: 6,
-                  background: m.reached ? 'rgba(201,162,74,0.7)' : 'rgba(255,255,255,0.12)',
+                  background: m.reached ? 'color-mix(in srgb, var(--gold) 70%, transparent)' : 'rgba(255,255,255,0.12)',
                   transition: 'background 0.4s ease',
                 }} />
               </div>
@@ -112,10 +112,10 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
             style={{
               position: 'absolute', top: 0, left: 0, bottom: 0,
               width: `${pct}%`, maxWidth: '100%',
-              background: 'linear-gradient(90deg, #8b3a1f, var(--gold))',
+              background: 'linear-gradient(90deg, var(--brick), var(--gold))',
               borderRadius: 8,
               transition: 'width 0.8s cubic-bezier(0.22,1,0.36,1)',
-              boxShadow: pct > 0 ? '0 0 12px rgba(201,162,74,0.55), 0 0 4px rgba(201,162,74,0.3)' : 'none',
+              boxShadow: pct > 0 ? '0 0 12px color-mix(in srgb, var(--gold) 55%, transparent), 0 0 4px color-mix(in srgb, var(--gold) 30%, transparent)' : 'none',
             }}
           />
 
@@ -130,7 +130,7 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
                 transform: 'translate(-50%, -50%)',
                 width: 8, height: 8, borderRadius: '50%',
                 background: 'var(--gold)',
-                boxShadow: '0 0 6px rgba(201,162,74,0.9)',
+                boxShadow: '0 0 6px color-mix(in srgb, var(--gold) 90%, transparent)',
                 zIndex: 1,
               }}
             />
@@ -146,7 +146,7 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
                 transform: 'translate(-50%, -50%)',
                 width: 16, height: 16, borderRadius: '50%',
                 background: 'radial-gradient(circle, #fff 30%, var(--gold) 100%)',
-                boxShadow: '0 0 8px rgba(201,162,74,1), 0 0 20px rgba(201,162,74,0.5)',
+                boxShadow: '0 0 8px var(--gold), 0 0 20px color-mix(in srgb, var(--gold) 50%, transparent)',
                 zIndex: 2,
                 transition: 'left 0.8s cubic-bezier(0.22,1,0.36,1)',
               }}
@@ -165,8 +165,8 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
           display: 'flex', alignItems: 'center', gap: 6,
           marginTop: '0.875rem',
           padding: '0.5rem 0.75rem',
-          background: 'rgba(201,162,74,0.07)',
-          border: '1px solid rgba(201,162,74,0.18)',
+          background: 'color-mix(in srgb, var(--gold) 7%, transparent)',
+          border: '1px solid color-mix(in srgb, var(--gold) 18%, transparent)',
           borderRadius: 8,
         }}>
           <span style={{ fontSize: 13 }}>★</span>

--- a/src/components/loyalty/LoyaltyCard.tsx
+++ b/src/components/loyalty/LoyaltyCard.tsx
@@ -29,10 +29,11 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
 
   return (
     <div
+      data-theme="dark"
       className="p-4 md:p-5"
       style={{
         background: 'linear-gradient(135deg, #0d0d10 0%, #1a1a20 50%, #0d0d10 100%)',
-        border: '1px solid color-mix(in srgb, var(--gold) 30%, transparent)',
+        border: '1px solid color-mix(in srgb, var(--card-accent) 30%, transparent)',
         borderRadius: 12,
         position: 'relative',
         overflow: 'hidden',
@@ -41,24 +42,24 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
       {/* Ambient glow */}
       <div style={{
         position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
-        background: 'radial-gradient(circle at 80% 20%, color-mix(in srgb, var(--gold) 6%, transparent) 0%, transparent 60%)',
+        background: 'radial-gradient(circle at 80% 20%, color-mix(in srgb, var(--card-accent) 6%, transparent) 0%, transparent 60%)',
         pointerEvents: 'none',
       }} />
 
       {/* Header */}
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1.25rem' }}>
         <div>
-          <div style={{ fontFamily: 'var(--font-display)', fontSize: 11, letterSpacing: '0.15em', color: 'var(--gold)', marginBottom: 2 }}>
+          <div style={{ fontFamily: 'var(--font-display)', fontSize: 11, letterSpacing: '0.15em', color: 'var(--card-accent)', marginBottom: 2 }}>
             GIO BLACK CARD
           </div>
           <div style={{ fontFamily: 'var(--font-display)', fontSize: 26, letterSpacing: '0.04em', color: '#fff' }}>
             {points.toLocaleString()}
-            <span style={{ fontSize: 14, color: 'var(--gold)', marginLeft: 4 }}>pts</span>
+            <span style={{ fontSize: 14, color: 'var(--card-accent)', marginLeft: 4 }}>pts</span>
           </div>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
-          <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10, color: 'color-mix(in srgb, var(--gold) 50%, transparent)' }}>MIEMBRO</div>
-          <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 11, color: 'var(--gold)', letterSpacing: '0.1em' }}>{memberCode}</div>
+          <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 10, color: 'color-mix(in srgb, var(--card-accent) 50%, transparent)' }}>MIEMBRO</div>
+          <div style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 11, color: 'var(--card-accent)', letterSpacing: '0.1em' }}>{memberCode}</div>
         </div>
       </div>
 
@@ -79,7 +80,7 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
               >
                 <span style={{
                   fontFamily: 'var(--font-mono, monospace)', fontSize: 8,
-                  color: m.reached ? 'var(--gold)' : 'rgba(255,255,255,0.25)',
+                  color: m.reached ? 'var(--card-accent)' : 'rgba(255,255,255,0.25)',
                   transition: 'color 0.4s ease',
                   whiteSpace: 'nowrap',
                   maxWidth: 60,
@@ -91,13 +92,13 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
                 </span>
                 <span style={{
                   fontFamily: 'var(--font-mono, monospace)', fontSize: 8,
-                  color: m.reached ? 'color-mix(in srgb, var(--gold) 70%, transparent)' : 'rgba(255,255,255,0.2)',
+                  color: m.reached ? 'color-mix(in srgb, var(--card-accent) 70%, transparent)' : 'rgba(255,255,255,0.2)',
                 }}>
                   {m.pts}
                 </span>
                 <div style={{
                   width: 1, height: 6,
-                  background: m.reached ? 'color-mix(in srgb, var(--gold) 70%, transparent)' : 'rgba(255,255,255,0.12)',
+                  background: m.reached ? 'color-mix(in srgb, var(--card-accent) 70%, transparent)' : 'rgba(255,255,255,0.12)',
                   transition: 'background 0.4s ease',
                 }} />
               </div>
@@ -112,10 +113,10 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
             style={{
               position: 'absolute', top: 0, left: 0, bottom: 0,
               width: `${pct}%`, maxWidth: '100%',
-              background: 'linear-gradient(90deg, var(--brick), var(--gold))',
+              background: 'linear-gradient(90deg, var(--brick), var(--card-accent))',
               borderRadius: 8,
               transition: 'width 0.8s cubic-bezier(0.22,1,0.36,1)',
-              boxShadow: pct > 0 ? '0 0 12px color-mix(in srgb, var(--gold) 55%, transparent), 0 0 4px color-mix(in srgb, var(--gold) 30%, transparent)' : 'none',
+              boxShadow: pct > 0 ? '0 0 12px color-mix(in srgb, var(--card-accent) 55%, transparent), 0 0 4px color-mix(in srgb, var(--card-accent) 30%, transparent)' : 'none',
             }}
           />
 
@@ -129,8 +130,8 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
                 top: '50%',
                 transform: 'translate(-50%, -50%)',
                 width: 8, height: 8, borderRadius: '50%',
-                background: 'var(--gold)',
-                boxShadow: '0 0 6px color-mix(in srgb, var(--gold) 90%, transparent)',
+                background: 'var(--card-accent)',
+                boxShadow: '0 0 6px color-mix(in srgb, var(--card-accent) 90%, transparent)',
                 zIndex: 1,
               }}
             />
@@ -145,8 +146,8 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
                 top: '50%',
                 transform: 'translate(-50%, -50%)',
                 width: 16, height: 16, borderRadius: '50%',
-                background: 'radial-gradient(circle, #fff 30%, var(--gold) 100%)',
-                boxShadow: '0 0 8px var(--gold), 0 0 20px color-mix(in srgb, var(--gold) 50%, transparent)',
+                background: 'radial-gradient(circle, #fff 30%, var(--card-accent) 100%)',
+                boxShadow: '0 0 8px var(--card-accent), 0 0 20px color-mix(in srgb, var(--card-accent) 50%, transparent)',
                 zIndex: 2,
                 transition: 'left 0.8s cubic-bezier(0.22,1,0.36,1)',
               }}
@@ -165,12 +166,12 @@ export function LoyaltyCard({ points, target, memberCode, rewards = [] }: Loyalt
           display: 'flex', alignItems: 'center', gap: 6,
           marginTop: '0.875rem',
           padding: '0.5rem 0.75rem',
-          background: 'color-mix(in srgb, var(--gold) 7%, transparent)',
-          border: '1px solid color-mix(in srgb, var(--gold) 18%, transparent)',
+          background: 'color-mix(in srgb, var(--card-accent) 7%, transparent)',
+          border: '1px solid color-mix(in srgb, var(--card-accent) 18%, transparent)',
           borderRadius: 8,
         }}>
           <span style={{ fontSize: 13 }}>★</span>
-          <span style={{ fontFamily: 'var(--font-ui)', fontSize: 12, color: 'var(--gold)', flex: 1 }}>
+          <span style={{ fontFamily: 'var(--font-ui)', fontSize: 12, color: 'var(--card-accent)', flex: 1 }}>
             {ptsToNext > 0 && nextReward
               ? <><strong>{ptsToNext} pts</strong> para <strong>{nextReward.label}</strong></>
               : <strong>¡Meta alcanzada! Canjea tu recompensa</strong>

--- a/src/context/ShopContext.tsx
+++ b/src/context/ShopContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext } from 'react'
 import { useShopInfo, useBookingConfig } from '@/hooks/useShopConfig'
+import { useApplyColorTheme } from '@/hooks/useColorTheme'
 import type { ShopInfo } from '@/domain/shop'
 import { DEFAULT_BOOKING_CONFIG } from '@/domain/shop'
 
@@ -33,6 +34,7 @@ const ShopContext = createContext<ShopContextValue | null>(null)
 export function ShopProvider({ children }: { children: React.ReactNode }) {
   const { data: shopInfo, isLoading: loadingInfo } = useShopInfo()
   const { data: bookingConfig, isLoading: loadingBooking } = useBookingConfig()
+  useApplyColorTheme()
 
   const info = shopInfo ?? DEFAULT_SHOP_INFO
   const booking = bookingConfig ?? DEFAULT_BOOKING_CONFIG

--- a/src/domain/colorTheme/index.ts
+++ b/src/domain/colorTheme/index.ts
@@ -1,0 +1,221 @@
+export type PaletteTokens = {
+  led: string
+  ledSoft: string
+  gold: string
+  brick: string
+  brickWarm: string
+}
+
+export type ColorPalette = {
+  id: string
+  name: string
+  nameEs: string
+  mode: 'dark' | 'light'
+  pairedWith: string
+  tokens: PaletteTokens
+}
+
+export type CustomPalette = {
+  id: string
+  name: string
+  mode: 'dark' | 'light'
+  tokens: PaletteTokens
+}
+
+export type ColorThemeConfig = {
+  activeDarkPaletteId: string | null
+  activeLightPaletteId: string | null
+  customPalettes: CustomPalette[]
+}
+
+export const PREDEFINED_PALETTES: ColorPalette[] = [
+  // — DARK (10) —
+  {
+    id: 'murasaki',
+    name: 'Murasaki 紫',
+    nameEs: 'Violeta noche',
+    mode: 'dark',
+    pairedWith: 'sakura',
+    tokens: { led: '#7b4fff', ledSoft: '#a689ff', gold: '#c9a24a', brick: '#8b3a1f', brickWarm: '#c06a3d' },
+  },
+  {
+    id: 'kon-ai',
+    name: 'Kon-ai 紺藍',
+    nameEs: 'Índigo profundo',
+    mode: 'dark',
+    pairedWith: 'hanada',
+    tokens: { led: '#1e4a9a', ledSoft: '#4a78d4', gold: '#c9a24a', brick: '#1a3560', brickWarm: '#3060a0' },
+  },
+  {
+    id: 'enji',
+    name: 'Enji 臙脂',
+    nameEs: 'Laca carmesí',
+    mode: 'dark',
+    pairedWith: 'kaki',
+    tokens: { led: '#8b1a35', ledSoft: '#c04060', gold: '#c0801a', brick: '#6a1525', brickWarm: '#a03050' },
+  },
+  {
+    id: 'rikyu',
+    name: 'Rikyū 利休',
+    nameEs: 'Té ceremonial',
+    mode: 'dark',
+    pairedWith: 'ukon',
+    tokens: { led: '#2d5a3d', ledSoft: '#4a8a62', gold: '#b8912a', brick: '#1e3d28', brickWarm: '#3a7050' },
+  },
+  {
+    id: 'nando',
+    name: 'Nando 納戸',
+    nameEs: 'Teal almacén',
+    mode: 'dark',
+    pairedWith: 'asagi',
+    tokens: { led: '#1a5c6e', ledSoft: '#3a8a9e', gold: '#c09a3a', brick: '#0e3a48', brickWarm: '#2a6878' },
+  },
+  {
+    id: 'rurikon',
+    name: 'Rurikon 瑠璃紺',
+    nameEs: 'Lapislázuli',
+    mode: 'dark',
+    pairedWith: 'shion',
+    tokens: { led: '#1e3578', ledSoft: '#3a5ab0', gold: '#d4a044', brick: '#142060', brickWarm: '#2a4890' },
+  },
+  {
+    id: 'fuji',
+    name: 'Fuji 藤',
+    nameEs: 'Glicinia',
+    mode: 'dark',
+    pairedWith: 'kohbai',
+    tokens: { led: '#7a3a8a', ledSoft: '#b060c0', gold: '#d4902a', brick: '#5a1a6a', brickWarm: '#9050a0' },
+  },
+  {
+    id: 'sohi',
+    name: 'Sohi 蘇芳',
+    nameEs: 'Madera de sapán',
+    mode: 'dark',
+    pairedWith: 'yamabuki',
+    tokens: { led: '#7a2a0e', ledSoft: '#b05030', gold: '#c09020', brick: '#501a08', brickWarm: '#904020' },
+  },
+  {
+    id: 'rokusho',
+    name: 'Rokushō 緑青',
+    nameEs: 'Pátina verdigris',
+    mode: 'dark',
+    pairedWith: 'moegi',
+    tokens: { led: '#1a5a4a', ledSoft: '#3a8a72', gold: '#c0901a', brick: '#0e3a30', brickWarm: '#2a7060' },
+  },
+  {
+    id: 'tsuyukusa',
+    name: 'Tsuyukusa 露草',
+    nameEs: 'Flor de rocío',
+    mode: 'dark',
+    pairedWith: 'tokiwa',
+    tokens: { led: '#1e4a7a', ledSoft: '#3a78b0', gold: '#d0a030', brick: '#143060', brickWarm: '#2a608a' },
+  },
+  // — LIGHT (10) —
+  {
+    id: 'sakura',
+    name: 'Sakura 桜',
+    nameEs: 'Cerezo en flor',
+    mode: 'light',
+    pairedWith: 'murasaki',
+    tokens: { led: '#b52860', ledSoft: '#d44a80', gold: '#9a6018', brick: '#8a1c48', brickWarm: '#c03868' },
+  },
+  {
+    id: 'hanada',
+    name: 'Hanada 縹',
+    nameEs: 'Azul celeste',
+    mode: 'light',
+    pairedWith: 'kon-ai',
+    tokens: { led: '#1a5a9a', ledSoft: '#3a7ac0', gold: '#8a5a14', brick: '#104078', brickWarm: '#2a6aaa' },
+  },
+  {
+    id: 'kaki',
+    name: 'Kaki 柿',
+    nameEs: 'Caqui naranja',
+    mode: 'light',
+    pairedWith: 'enji',
+    tokens: { led: '#9a4010', ledSoft: '#c06030', gold: '#7a4800', brick: '#7a2800', brickWarm: '#b05020' },
+  },
+  {
+    id: 'ukon',
+    name: 'Ukon 鬱金',
+    nameEs: 'Cúrcuma ámbar',
+    mode: 'light',
+    pairedWith: 'rikyu',
+    tokens: { led: '#8a5000', ledSoft: '#b87020', gold: '#6a3800', brick: '#7a3800', brickWarm: '#a05010' },
+  },
+  {
+    id: 'asagi',
+    name: 'Asagi 浅葱',
+    nameEs: 'Teal suave',
+    mode: 'light',
+    pairedWith: 'nando',
+    tokens: { led: '#1a6a78', ledSoft: '#2a8a9a', gold: '#7a5010', brick: '#0a4850', brickWarm: '#1a7880' },
+  },
+  {
+    id: 'shion',
+    name: 'Shion 紫苑',
+    nameEs: 'Aster lila',
+    mode: 'light',
+    pairedWith: 'rurikon',
+    tokens: { led: '#6a3a8a', ledSoft: '#9060b0', gold: '#8a5814', brick: '#4a2068', brickWarm: '#803898' },
+  },
+  {
+    id: 'kohbai',
+    name: 'Kōbai 紅梅',
+    nameEs: 'Ciruela roja',
+    mode: 'light',
+    pairedWith: 'fuji',
+    tokens: { led: '#9a2040', ledSoft: '#c04060', gold: '#8a5814', brick: '#701830', brickWarm: '#a83050' },
+  },
+  {
+    id: 'yamabuki',
+    name: 'Yamabuki 山吹',
+    nameEs: 'Rosa de montaña',
+    mode: 'light',
+    pairedWith: 'sohi',
+    tokens: { led: '#9a6800', ledSoft: '#c88a10', gold: '#6a4400', brick: '#7a4400', brickWarm: '#b07010' },
+  },
+  {
+    id: 'moegi',
+    name: 'Moegi 萌葱',
+    nameEs: 'Brote de primavera',
+    mode: 'light',
+    pairedWith: 'rokusho',
+    tokens: { led: '#1a6a3a', ledSoft: '#2a8a50', gold: '#7a5010', brick: '#0a4a28', brickWarm: '#1a7040' },
+  },
+  {
+    id: 'tokiwa',
+    name: 'Tokiwa 常磐',
+    nameEs: 'Pino sempreverde',
+    mode: 'light',
+    pairedWith: 'tsuyukusa',
+    tokens: { led: '#1a5830', ledSoft: '#288050', gold: '#7a5010', brick: '#0e3a20', brickWarm: '#1a6838' },
+  },
+]
+
+export function getPaletteById(
+  id: string,
+  customs: CustomPalette[] = [],
+): ColorPalette | CustomPalette | undefined {
+  return (
+    PREDEFINED_PALETTES.find((p) => p.id === id) ?? customs.find((c) => c.id === id)
+  )
+}
+
+export function buildPaletteCSS(
+  darkTokens: PaletteTokens | null,
+  lightTokens: PaletteTokens | null,
+): string {
+  const blocks: string[] = []
+  if (darkTokens) {
+    blocks.push(
+      `:root, [data-theme='dark'] { --led: ${darkTokens.led}; --led-soft: ${darkTokens.ledSoft}; --gold: ${darkTokens.gold}; --brick: ${darkTokens.brick}; --brick-warm: ${darkTokens.brickWarm}; }`,
+    )
+  }
+  if (lightTokens) {
+    blocks.push(
+      `[data-theme='light'] { --led: ${lightTokens.led}; --led-soft: ${lightTokens.ledSoft}; --gold: ${lightTokens.gold}; --brick: ${lightTokens.brick}; --brick-warm: ${lightTokens.brickWarm}; }`,
+    )
+  }
+  return blocks.join('\n')
+}

--- a/src/domain/colorTheme/index.ts
+++ b/src/domain/colorTheme/index.ts
@@ -4,6 +4,7 @@ export type PaletteTokens = {
   gold: string
   brick: string
   brickWarm: string
+  cardAccent?: string
 }
 
 export type ColorPalette = {
@@ -39,7 +40,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Violeta noche',
     mode: 'dark',
     pairedWith: 'sakura',
-    tokens: { led: '#7b4fff', ledSoft: '#a689ff', gold: '#c9a24a', brick: '#8b3a1f', brickWarm: '#c06a3d' },
+    tokens: { led: '#7b4fff', ledSoft: '#a689ff', gold: '#c9a24a', brick: '#8b3a1f', brickWarm: '#c06a3d', cardAccent: '#c9a24a' },
   },
   {
     id: 'kon-ai',
@@ -47,7 +48,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Índigo profundo',
     mode: 'dark',
     pairedWith: 'hanada',
-    tokens: { led: '#1e4a9a', ledSoft: '#4a78d4', gold: '#c9a24a', brick: '#1a3560', brickWarm: '#3060a0' },
+    tokens: { led: '#1e4a9a', ledSoft: '#4a78d4', gold: '#c9a24a', brick: '#1a3560', brickWarm: '#3060a0', cardAccent: '#b8a44a' },
   },
   {
     id: 'enji',
@@ -55,7 +56,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Laca carmesí',
     mode: 'dark',
     pairedWith: 'kaki',
-    tokens: { led: '#8b1a35', ledSoft: '#c04060', gold: '#c0801a', brick: '#6a1525', brickWarm: '#a03050' },
+    tokens: { led: '#8b1a35', ledSoft: '#c04060', gold: '#c0801a', brick: '#6a1525', brickWarm: '#a03050', cardAccent: '#d4893a' },
   },
   {
     id: 'rikyu',
@@ -63,7 +64,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Té ceremonial',
     mode: 'dark',
     pairedWith: 'ukon',
-    tokens: { led: '#2d5a3d', ledSoft: '#4a8a62', gold: '#b8912a', brick: '#1e3d28', brickWarm: '#3a7050' },
+    tokens: { led: '#2d5a3d', ledSoft: '#4a8a62', gold: '#b8912a', brick: '#1e3d28', brickWarm: '#3a7050', cardAccent: '#c89540' },
   },
   {
     id: 'nando',
@@ -71,7 +72,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Teal almacén',
     mode: 'dark',
     pairedWith: 'asagi',
-    tokens: { led: '#1a5c6e', ledSoft: '#3a8a9e', gold: '#c09a3a', brick: '#0e3a48', brickWarm: '#2a6878' },
+    tokens: { led: '#1a5c6e', ledSoft: '#3a8a9e', gold: '#c09a3a', brick: '#0e3a48', brickWarm: '#2a6878', cardAccent: '#c09a3a' },
   },
   {
     id: 'rurikon',
@@ -79,7 +80,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Lapislázuli',
     mode: 'dark',
     pairedWith: 'shion',
-    tokens: { led: '#1e3578', ledSoft: '#3a5ab0', gold: '#d4a044', brick: '#142060', brickWarm: '#2a4890' },
+    tokens: { led: '#1e3578', ledSoft: '#3a5ab0', gold: '#d4a044', brick: '#142060', brickWarm: '#2a4890', cardAccent: '#caa840' },
   },
   {
     id: 'fuji',
@@ -87,7 +88,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Glicinia',
     mode: 'dark',
     pairedWith: 'kohbai',
-    tokens: { led: '#7a3a8a', ledSoft: '#b060c0', gold: '#d4902a', brick: '#5a1a6a', brickWarm: '#9050a0' },
+    tokens: { led: '#7a3a8a', ledSoft: '#b060c0', gold: '#d4902a', brick: '#5a1a6a', brickWarm: '#9050a0', cardAccent: '#c89548' },
   },
   {
     id: 'sohi',
@@ -95,7 +96,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Madera de sapán',
     mode: 'dark',
     pairedWith: 'yamabuki',
-    tokens: { led: '#7a2a0e', ledSoft: '#b05030', gold: '#c09020', brick: '#501a08', brickWarm: '#904020' },
+    tokens: { led: '#7a2a0e', ledSoft: '#b05030', gold: '#c09020', brick: '#501a08', brickWarm: '#904020', cardAccent: '#d49038' },
   },
   {
     id: 'rokusho',
@@ -103,7 +104,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Pátina verdigris',
     mode: 'dark',
     pairedWith: 'moegi',
-    tokens: { led: '#1a5a4a', ledSoft: '#3a8a72', gold: '#c0901a', brick: '#0e3a30', brickWarm: '#2a7060' },
+    tokens: { led: '#1a5a4a', ledSoft: '#3a8a72', gold: '#c0901a', brick: '#0e3a30', brickWarm: '#2a7060', cardAccent: '#c8a03a' },
   },
   {
     id: 'tsuyukusa',
@@ -111,7 +112,7 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     nameEs: 'Flor de rocío',
     mode: 'dark',
     pairedWith: 'tokiwa',
-    tokens: { led: '#1e4a7a', ledSoft: '#3a78b0', gold: '#d0a030', brick: '#143060', brickWarm: '#2a608a' },
+    tokens: { led: '#1e4a7a', ledSoft: '#3a78b0', gold: '#d0a030', brick: '#143060', brickWarm: '#2a608a', cardAccent: '#c09845' },
   },
   // — LIGHT (11: original + 10 Sanzo Wada) —
   {
@@ -231,7 +232,7 @@ export function buildPaletteCSS(
   const blocks: string[] = []
   if (darkTokens) {
     blocks.push(
-      `:root, [data-theme='dark'] { --led: ${darkTokens.led}; --led-soft: ${darkTokens.ledSoft}; --gold: ${darkTokens.gold}; --brick: ${darkTokens.brick}; --brick-warm: ${darkTokens.brickWarm}; }`,
+      `:root, [data-theme='dark'] { --led: ${darkTokens.led}; --led-soft: ${darkTokens.ledSoft}; --gold: ${darkTokens.gold}; --brick: ${darkTokens.brick}; --brick-warm: ${darkTokens.brickWarm}; --card-accent: ${darkTokens.cardAccent ?? darkTokens.gold}; }`,
     )
   }
   if (lightTokens) {

--- a/src/domain/colorTheme/index.ts
+++ b/src/domain/colorTheme/index.ts
@@ -193,6 +193,17 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
   },
 ]
 
+export function deriveAccentVariant(hex: string, mode: 'dark' | 'light'): string {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  const mix = mode === 'dark' ? 180 : 80
+  const nr = Math.round(r + (mix - r) * 0.45)
+  const ng = Math.round(g + (mix - g) * 0.45)
+  const nb = Math.round(b + (mix - b) * 0.45)
+  return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`
+}
+
 export function getPaletteById(
   id: string,
   customs: CustomPalette[] = [],

--- a/src/domain/colorTheme/index.ts
+++ b/src/domain/colorTheme/index.ts
@@ -28,6 +28,9 @@ export type ColorThemeConfig = {
   customPalettes: CustomPalette[]
 }
 
+export const DEFAULT_DARK_PALETTE_ID = 'murasaki'
+export const DEFAULT_LIGHT_PALETTE_ID = 'gio-original'
+
 export const PREDEFINED_PALETTES: ColorPalette[] = [
   // — DARK (10) —
   {
@@ -110,7 +113,15 @@ export const PREDEFINED_PALETTES: ColorPalette[] = [
     pairedWith: 'tokiwa',
     tokens: { led: '#1e4a7a', ledSoft: '#3a78b0', gold: '#d0a030', brick: '#143060', brickWarm: '#2a608a' },
   },
-  // — LIGHT (10) —
+  // — LIGHT (11: original + 10 Sanzo Wada) —
+  {
+    id: 'gio-original',
+    name: 'Original Claro',
+    nameEs: 'Paleta original de la app',
+    mode: 'light',
+    pairedWith: 'murasaki',
+    tokens: { led: '#6235e0', ledSoft: '#7b4fff', gold: '#a88030', brick: '#a04528', brickWarm: '#b0552d' },
+  },
   {
     id: 'sakura',
     name: 'Sakura 桜',

--- a/src/domain/shop/index.ts
+++ b/src/domain/shop/index.ts
@@ -27,10 +27,14 @@ export const DEFAULT_BOOKING_CONFIG: BookingConfig = {
   bufferMinutes: 0,
 }
 
+import type { ColorThemeConfig } from '@/domain/colorTheme'
+
 export interface IShopRepository {
   getShopInfo(): Promise<ShopInfo | null>
   getBookingConfig(): Promise<BookingConfig | null>
   getLoyaltyConfig(): Promise<LoyaltyConfig | null>
+  getColorTheme(): Promise<ColorThemeConfig | null>
   updateShopInfo(info: Partial<ShopInfo>): Promise<void>
   updateBookingConfig(config: Partial<BookingConfig>): Promise<void>
+  updateColorTheme(config: ColorThemeConfig): Promise<void>
 }

--- a/src/hooks/queryKeys.ts
+++ b/src/hooks/queryKeys.ts
@@ -9,12 +9,13 @@
 
 export const queryKeys = {
   shop: {
-    all:     () => ['shop'] as const,
-    info:    () => ['shop', 'info'] as const,
-    booking: () => ['shop', 'booking'] as const,
-    loyalty: () => ['shop', 'loyalty'] as const,
+    all:        () => ['shop'] as const,
+    info:       () => ['shop', 'info'] as const,
+    booking:    () => ['shop', 'booking'] as const,
+    loyalty:    () => ['shop', 'loyalty'] as const,
+    colorTheme: () => ['shop', 'color-theme'] as const,
     /** @deprecated use shop.info / shop.booking instead */
-    config:  () => ['shop', 'config'] as const,
+    config:     () => ['shop', 'config'] as const,
   },
 
   services: {

--- a/src/hooks/useColorTheme.ts
+++ b/src/hooks/useColorTheme.ts
@@ -37,7 +37,12 @@ export function useApplyColorTheme() {
       ? getPaletteById(config.activeLightPaletteId, customs)
       : null
 
-    if (!darkPalette && !lightPalette) return
+    if (!darkPalette && !lightPalette) {
+      const el = document.getElementById(PALETTE_STYLE_ID) as HTMLStyleElement | null
+      if (el) el.textContent = ''
+      localStorage.removeItem(PALETTE_CSS_KEY)
+      return
+    }
 
     const css = buildPaletteCSS(
       darkPalette?.tokens ?? null,

--- a/src/hooks/useColorTheme.ts
+++ b/src/hooks/useColorTheme.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { repositories } from '@/infrastructure'
+import type { ColorThemeConfig } from '@/domain/colorTheme'
+import { getPaletteById, buildPaletteCSS } from '@/domain/colorTheme'
+import { queryKeys, STALE } from './queryKeys'
+
+const PALETTE_STYLE_ID = 'gio-palette-style'
+const PALETTE_CSS_KEY = 'gio_palette_css'
+
+export function useColorTheme() {
+  return useQuery({
+    queryKey: queryKeys.shop.colorTheme(),
+    queryFn: () => repositories.shop().getColorTheme(),
+    staleTime: STALE.LONG,
+  })
+}
+
+export function useMutateColorTheme() {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (config: ColorThemeConfig) =>
+      repositories.shop().updateColorTheme(config),
+    onSuccess: () => qc.invalidateQueries({ queryKey: queryKeys.shop.colorTheme() }),
+  })
+}
+
+export function useApplyColorTheme() {
+  const { data: config } = useColorTheme()
+
+  useEffect(() => {
+    const customs = config?.customPalettes ?? []
+    const darkPalette = config?.activeDarkPaletteId
+      ? getPaletteById(config.activeDarkPaletteId, customs)
+      : null
+    const lightPalette = config?.activeLightPaletteId
+      ? getPaletteById(config.activeLightPaletteId, customs)
+      : null
+
+    if (!darkPalette && !lightPalette) return
+
+    const css = buildPaletteCSS(
+      darkPalette?.tokens ?? null,
+      lightPalette?.tokens ?? null,
+    )
+
+    let el = document.getElementById(PALETTE_STYLE_ID) as HTMLStyleElement | null
+    if (!el) {
+      el = document.createElement('style')
+      el.id = PALETTE_STYLE_ID
+      document.head.appendChild(el)
+    }
+    el.textContent = css
+    localStorage.setItem(PALETTE_CSS_KEY, css)
+  }, [config])
+}

--- a/src/infrastructure/insforge/appointmentRepository.ts
+++ b/src/infrastructure/insforge/appointmentRepository.ts
@@ -20,6 +20,16 @@ interface AppointmentRow {
   profiles?: { full_name: string | null } | null
 }
 
+// InsForge SDK returns profiles as an array for embedded joins; normalize before mapping
+type AppointmentRowRaw = Omit<AppointmentRow, 'profiles'> & {
+  profiles: Array<{ full_name: string | null }> | { full_name: string | null } | null
+}
+
+function normalizeRow(raw: AppointmentRowRaw): AppointmentRow {
+  const profiles = Array.isArray(raw.profiles) ? (raw.profiles[0] ?? null) : (raw.profiles ?? null)
+  return { ...raw, profiles }
+}
+
 function mapToAppointment(row: AppointmentRow): Appointment {
   return {
     id: row.id,
@@ -58,7 +68,7 @@ export class InsForgeAppointmentRepository implements IAppointmentRepository {
       .select(SELECT_FIELDS_WITH_CLIENT)
       .order('start_time', { ascending: false })
     if (error) throw error
-    return ((data ?? []) as unknown as AppointmentRow[]).map(mapToAppointment)
+    return ((data ?? []) as AppointmentRowRaw[]).map((row) => mapToAppointment(normalizeRow(row)))
   }
 
   async create(appt: CreateAppointmentData): Promise<Appointment> {

--- a/src/infrastructure/insforge/appointmentRepository.ts
+++ b/src/infrastructure/insforge/appointmentRepository.ts
@@ -17,14 +17,14 @@ interface AppointmentRow {
   status: string
   notes: string | null
   created_at: string
-  profiles?: { full_name: string | null }[] | null
+  profiles?: { full_name: string | null } | null
 }
 
 function mapToAppointment(row: AppointmentRow): Appointment {
   return {
     id: row.id,
     clientId: row.client_id,
-    clientName: row.profiles?.[0]?.full_name ?? undefined,
+    clientName: row.profiles?.full_name ?? undefined,
     barberId: row.barber_id,
     serviceId: row.service_id,
     startTime: row.start_time,
@@ -58,7 +58,7 @@ export class InsForgeAppointmentRepository implements IAppointmentRepository {
       .select(SELECT_FIELDS_WITH_CLIENT)
       .order('start_time', { ascending: false })
     if (error) throw error
-    return ((data ?? []) as AppointmentRow[]).map(mapToAppointment)
+    return ((data ?? []) as unknown as AppointmentRow[]).map(mapToAppointment)
   }
 
   async create(appt: CreateAppointmentData): Promise<Appointment> {

--- a/src/infrastructure/insforge/shopRepository.ts
+++ b/src/infrastructure/insforge/shopRepository.ts
@@ -1,4 +1,5 @@
 import type { IShopRepository, ShopInfo, BookingConfig, LoyaltyConfig } from '@/domain/shop'
+import type { ColorThemeConfig } from '@/domain/colorTheme'
 import { insforgeClient } from './client'
 
 interface ShopConfigRow {
@@ -44,5 +45,13 @@ export class InsForgeShopRepository implements IShopRepository {
   async updateBookingConfig(config: Partial<BookingConfig>): Promise<void> {
     const current = await this.getBookingConfig()
     await upsertConfigValue('booking', { ...current, ...config })
+  }
+
+  getColorTheme(): Promise<ColorThemeConfig | null> {
+    return getConfigValue<ColorThemeConfig>('color_theme')
+  }
+
+  async updateColorTheme(config: ColorThemeConfig): Promise<void> {
+    await upsertConfigValue('color_theme', config)
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,15 @@ const queryClient = new QueryClient({
 })
 
 async function bootstrap() {
+  // Inject cached palette CSS synchronously before first render to prevent color flash
+  const cachedCSS = localStorage.getItem('gio_palette_css')
+  if (cachedCSS) {
+    const el = document.createElement('style')
+    el.id = 'gio-palette-style'
+    el.textContent = cachedCSS
+    document.head.appendChild(el)
+  }
+
   if (import.meta.env.VITE_USE_MOCKS === 'true') {
     const { worker } = await import('./mocks/browser')
     await worker.start({ onUnhandledRequest: 'warn' })

--- a/src/pages/admin/SettingsPage.tsx
+++ b/src/pages/admin/SettingsPage.tsx
@@ -15,8 +15,9 @@ import type { WeeklySchedule, DayKey } from '@/domain/schedule'
 import type { Service } from '@/domain/service'
 import type { Barber } from '@/domain/barber'
 import type { Reward } from '@/domain/loyalty'
+import { AppearanceSection } from '@/components/appearance'
 
-type Section = 'servicios' | 'horarios' | 'barberos' | 'fidelizacion' | 'barberia'
+type Section = 'servicios' | 'horarios' | 'barberos' | 'fidelizacion' | 'barberia' | 'apariencia'
 
 const BARBER_ROLES = ['Barbero', 'Propietario'] as const
 
@@ -26,6 +27,7 @@ const SECTIONS: { id: Section; label: string }[] = [
   { id: 'barberos',     label: 'Barberos' },
   { id: 'fidelizacion', label: 'Fidelización' },
   { id: 'barberia',     label: 'Barbería' },
+  { id: 'apariencia',   label: 'Apariencia' },
 ]
 
 const DAY_KEYS: { key: DayKey; name: string }[] = [
@@ -363,6 +365,7 @@ export default function SettingsPage() {
     barberos:     Object.keys(barberEdits).length > 0,
     fidelizacion: Object.keys(rewardEdits).length > 0,
     barberia:     Object.keys(shopEdits).length > 0,
+    apariencia:   false, // AppearanceSection manages its own confirm dialog
   }
   const anyDirty = Object.values(sectionDirty).some(Boolean)
 
@@ -980,6 +983,14 @@ export default function SettingsPage() {
               {sectionError.fidelizacion && (
                 <p style={{ color: 'var(--danger)', fontSize: 12, fontFamily: 'var(--font-ui)', marginTop: 8, marginBottom: 0 }}>{sectionError.fidelizacion}</p>
               )}
+            </div>
+          )}
+
+          {/* === APARIENCIA === */}
+          {section === 'apariencia' && (
+            <div>
+              <SectionTitle>APARIENCIA</SectionTitle>
+              <AppearanceSection />
             </div>
           )}
 

--- a/src/pages/admin/SettingsPage.tsx
+++ b/src/pages/admin/SettingsPage.tsx
@@ -95,6 +95,8 @@ function SaveBtn({ onClick, loading, isDirty }: { onClick: () => void; loading?:
 
 export default function SettingsPage() {
   const { user } = useAuth()
+  const isAdmin = user?.role === 'admin'
+  const visibleSections = isAdmin ? SECTIONS : SECTIONS.filter(s => s.id !== 'apariencia')
   const { name: shopName, allowBarberChoice } = useShopContext()
   const [section, setSection] = useState<Section>('servicios')
   const [pendingNavSection, setPendingNavSection] = useState<Section | null>(null)
@@ -425,7 +427,7 @@ export default function SettingsPage() {
       {/* Mobile section tabs */}
       <div className="md:hidden overflow-x-auto pb-2 mb-4 -mx-4 px-4">
         <div className="flex gap-2 w-max">
-          {SECTIONS.map(s => (
+          {visibleSections.map(s => (
             <button
               key={s.id}
               onClick={() => handleSectionChange(s.id)}
@@ -455,7 +457,7 @@ export default function SettingsPage() {
           className="hidden md:block"
           style={{ background: 'var(--bg-2)', border: '1px solid var(--line)', borderRadius: 12, padding: '0.5rem', position: 'sticky', top: 72 }}
         >
-          {SECTIONS.map(s => (
+          {visibleSections.map(s => (
             <button key={s.id} onClick={() => handleSectionChange(s.id)} style={sidebarBtn(s.id)}>
               <span style={{ flex: 1 }}>{s.label}</span>
               {sectionDirty[s.id] && (
@@ -987,7 +989,7 @@ export default function SettingsPage() {
           )}
 
           {/* === APARIENCIA === */}
-          {section === 'apariencia' && (
+          {section === 'apariencia' && isAdmin && (
             <div>
               <SectionTitle>APARIENCIA</SectionTitle>
               <AppearanceSection />

--- a/src/pages/admin/SettingsPage.tsx
+++ b/src/pages/admin/SettingsPage.tsx
@@ -442,6 +442,9 @@ export default function SettingsPage() {
               }}
             >
               {s.label}
+              {s.id === 'apariencia' && (
+                <span style={{ fontSize: 8, fontWeight: 700, letterSpacing: '0.08em', padding: '1px 5px', borderRadius: 4, background: 'rgba(200,164,78,0.2)', color: section === s.id ? '#7a5a00' : '#c8a44e', flexShrink: 0 }}>ADMIN</span>
+              )}
               {sectionDirty[s.id] && (
                 <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: '50%', background: section === s.id ? '#000' : 'var(--led)', flexShrink: 0 }} />
               )}
@@ -460,6 +463,9 @@ export default function SettingsPage() {
           {visibleSections.map(s => (
             <button key={s.id} onClick={() => handleSectionChange(s.id)} style={sidebarBtn(s.id)}>
               <span style={{ flex: 1 }}>{s.label}</span>
+              {s.id === 'apariencia' && (
+                <span style={{ fontSize: 8, fontWeight: 700, letterSpacing: '0.08em', padding: '1px 5px', borderRadius: 4, background: 'rgba(200,164,78,0.2)', color: '#c8a44e', flexShrink: 0 }}>ADMIN</span>
+              )}
               {sectionDirty[s.id] && (
                 <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--led)', flexShrink: 0 }} />
               )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -20,6 +20,7 @@
   --led: #7b4fff;
   --led-soft: #a689ff;
   --gold: #c9a24a;
+  --card-accent: var(--gold);
   --danger: #c04040;
   --ok: #6dbb6d;
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);


### PR DESCRIPTION
Closes #69

## Summary
- Añade sección "Apariencia" en SettingsPage (solo `role='admin'`) con 20 paletas predefinidas (10 dark, 10 light) basadas en el sistema Sanzo Wada
- Preview en tiempo real: `PreviewAppointmentsMock` (dark) + `PreviewCalendarMock` (light), con la tarjeta de fidelización visible en el preview oscuro
- Token `--card-accent` por paleta dark para que la loyalty card muestre un dorado/acento específico por paleta
- Badge "ADMIN" en sidebar y tabs de SettingsPage para indicar que la sección está restringida
- Editor de paleta personalizada: permite ajustar 3 tokens (led, gold, brick) con color picker nativo
- La paleta persiste en `shop_config` key `color_theme` + `localStorage`; se inyecta como CSS vars en `<html>` antes de que cargue React (sin flash)
- Compatible con el toggle dark/light existente del TopBar

## Test plan
- [ ] Seleccionar paleta dark → preview AppointmentsMock cambia en tiempo real
- [ ] Seleccionar paleta light → preview CalendarMock cambia en tiempo real
- [ ] La tarjeta de fidelización muestra el acento correcto (`--card-accent`) de cada paleta
- [ ] Guardar paleta → persiste al recargar la página (localStorage + shop_config)
- [ ] Usuario con `role='client'` no ve la sección Apariencia
- [ ] Badge "ADMIN" visible en sidebar (desktop) y tabs (mobile)
- [ ] Editor de paleta personalizada: cambiar colores y ver preview actualizado
- [ ] Toggle dark/light del TopBar sigue funcionando con cualquier paleta activa

🤖 Generated with [Claude Code](https://claude.com/claude-code)